### PR TITLE
feat: switch from BurntSushi to Pelletier TOML library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,15 +5,15 @@ go 1.23.0
 toolchain go1.24.4
 
 require (
-	github.com/BurntSushi/toml v1.6.0
+	github.com/infodancer/maildir v0.0.0-20260119021101-d8a459a938d1
 	github.com/infodancer/msgstore v0.0.0-20260118175617-5fc41afaac0b
+	github.com/pelletier/go-toml/v2 v2.2.3
 	github.com/prometheus/client_golang v1.23.2
 )
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/infodancer/maildir v0.0.0-20260119021101-d8a459a938d1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
-github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -23,6 +21,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
+github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/BurntSushi/toml"
+	toml "github.com/pelletier/go-toml/v2"
 )
 
 // Flags holds command-line flag values.
@@ -53,7 +53,7 @@ func Load(path string) (Config, error) {
 	}
 
 	var fileConfig FileConfig
-	if _, err := toml.Decode(string(data), &fileConfig); err != nil {
+	if err := toml.Unmarshal(data, &fileConfig); err != nil {
 		return cfg, fmt.Errorf("parsing config file: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

- Replace `github.com/BurntSushi/toml` with `github.com/pelletier/go-toml/v2` for TOML parsing
- Update import in `internal/config/loader.go` to use the new library
- Change function call from `toml.Decode(string(data), &cfg)` to `toml.Unmarshal(data, &cfg)`

Fixes #28

## Test plan

- [x] Run `go mod tidy` to verify dependency resolution
- [x] Run `go build ./...` to verify compilation
- [x] Run `go test ./internal/config/...` to verify config tests pass
- [x] Run `task test` to verify full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)