### PR TITLE
feat: use msgstore registry pattern for pluggable storage backends

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -73,8 +73,8 @@ tasks:
   serve:
     desc: Start local SMTP server with maildir delivery to temp directory
     vars:
-      MAILDIR:
+      DELIVERY_PATH:
         sh: mktemp -d -t smtpd-maildir-XXXXXX
     cmds:
-      - 'echo "Maildir storage: {{.MAILDIR}}"'
-      - go run ./cmd/smtpd -listen localhost:2525 -maildir {{.MAILDIR}} -log-level debug
+      - 'echo "Delivery storage: {{.DELIVERY_PATH}}"'
+      - go run ./cmd/smtpd -listen localhost:2525 -delivery-type maildir -delivery-path {{.DELIVERY_PATH}} -log-level debug

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,7 @@ go 1.23.0
 toolchain go1.24.4
 
 require (
-	github.com/infodancer/maildir v0.0.0-20260119021101-d8a459a938d1
-	github.com/infodancer/msgstore v0.0.0-20260118175617-5fc41afaac0b
+	github.com/infodancer/msgstore v0.0.0-20260119122628-46a831f8f899
 	github.com/pelletier/go-toml/v2 v2.2.3
 	github.com/prometheus/client_golang v1.23.2
 )

--- a/go.sum
+++ b/go.sum
@@ -7,10 +7,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/infodancer/maildir v0.0.0-20260119021101-d8a459a938d1 h1:fLDGjC4HIJgwOGeY40E7YepFnVHXzH7LPWba+v8oseU=
-github.com/infodancer/maildir v0.0.0-20260119021101-d8a459a938d1/go.mod h1:v5/2BAIoAN7b6p8cidRuvtuwt7S0r2EThn57SNFnjlI=
-github.com/infodancer/msgstore v0.0.0-20260118175617-5fc41afaac0b h1:NYpmx6N556oV3pkysTbWPjFrDsCoadAyIMnf0BePyOA=
-github.com/infodancer/msgstore v0.0.0-20260118175617-5fc41afaac0b/go.mod h1:l8ooXfpt+UDDNSrg4IKQYglqRqIjp2Ei3GgOKdJVk00=
+github.com/infodancer/msgstore v0.0.0-20260119122628-46a831f8f899 h1:bxXLCWJbifXaherjSvcE5vLWlVJG67Xuqpo/Xxi6Wgc=
+github.com/infodancer/msgstore v0.0.0-20260119122628-46a831f8f899/go.mod h1:l8ooXfpt+UDDNSrg4IKQYglqRqIjp2Ei3GgOKdJVk00=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,9 +31,9 @@ type FileConfig struct {
 
 // ServerConfig holds shared settings used by all mail services.
 type ServerConfig struct {
-	Hostname string    `toml:"hostname"`
-	Maildir  string    `toml:"maildir"`
-	TLS      TLSConfig `toml:"tls"`
+	Hostname string         `toml:"hostname"`
+	Delivery DeliveryConfig `toml:"delivery"`
+	TLS      TLSConfig      `toml:"tls"`
 }
 
 // Config holds the complete SMTP server configuration.
@@ -81,8 +81,11 @@ type MetricsConfig struct {
 }
 
 // DeliveryConfig holds configuration for message delivery.
+// Uses the msgstore registry pattern for pluggable storage backends.
 type DeliveryConfig struct {
-	Maildir string `toml:"maildir"`
+	Type     string            `toml:"type"`      // Storage backend type (e.g., "maildir")
+	BasePath string            `toml:"base_path"` // Base path for storage
+	Options  map[string]string `toml:"options"`   // Backend-specific options
 }
 
 // Default returns a Config with sensible default values.

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -18,7 +18,8 @@ type Flags struct {
 	TLSKey         string
 	MaxMessageSize int
 	MaxRecipients  int
-	Maildir        string
+	DeliveryType   string
+	DeliveryPath   string
 }
 
 // ParseFlags parses command-line flags and returns a Flags struct.
@@ -33,7 +34,8 @@ func ParseFlags() *Flags {
 	flag.StringVar(&f.TLSKey, "tls-key", "", "TLS key file path")
 	flag.IntVar(&f.MaxMessageSize, "max-message-size", 0, "Maximum message size in bytes")
 	flag.IntVar(&f.MaxRecipients, "max-recipients", 0, "Maximum recipients per message")
-	flag.StringVar(&f.Maildir, "maildir", "", "Maildir path for message delivery")
+	flag.StringVar(&f.DeliveryType, "delivery-type", "", "Delivery storage type (e.g., maildir)")
+	flag.StringVar(&f.DeliveryPath, "delivery-path", "", "Delivery storage base path")
 
 	flag.Parse()
 	return f
@@ -102,8 +104,12 @@ func ApplyFlags(cfg Config, f *Flags) Config {
 		cfg.Limits.MaxRecipients = f.MaxRecipients
 	}
 
-	if f.Maildir != "" {
-		cfg.Delivery.Maildir = f.Maildir
+	if f.DeliveryType != "" {
+		cfg.Delivery.Type = f.DeliveryType
+	}
+
+	if f.DeliveryPath != "" {
+		cfg.Delivery.BasePath = f.DeliveryPath
 	}
 
 	return cfg
@@ -125,8 +131,21 @@ func mergeServerConfig(dst Config, src ServerConfig) Config {
 		dst.Hostname = src.Hostname
 	}
 
-	if src.Maildir != "" {
-		dst.Delivery.Maildir = src.Maildir
+	if src.Delivery.Type != "" {
+		dst.Delivery.Type = src.Delivery.Type
+	}
+
+	if src.Delivery.BasePath != "" {
+		dst.Delivery.BasePath = src.Delivery.BasePath
+	}
+
+	if len(src.Delivery.Options) > 0 {
+		if dst.Delivery.Options == nil {
+			dst.Delivery.Options = make(map[string]string)
+		}
+		for k, v := range src.Delivery.Options {
+			dst.Delivery.Options[k] = v
+		}
 	}
 
 	if src.TLS.CertFile != "" {
@@ -199,8 +218,21 @@ func mergeConfig(dst, src Config) Config {
 		dst.Metrics.Path = src.Metrics.Path
 	}
 
-	if src.Delivery.Maildir != "" {
-		dst.Delivery.Maildir = src.Delivery.Maildir
+	if src.Delivery.Type != "" {
+		dst.Delivery.Type = src.Delivery.Type
+	}
+
+	if src.Delivery.BasePath != "" {
+		dst.Delivery.BasePath = src.Delivery.BasePath
+	}
+
+	if len(src.Delivery.Options) > 0 {
+		if dst.Delivery.Options == nil {
+			dst.Delivery.Options = make(map[string]string)
+		}
+		for k, v := range src.Delivery.Options {
+			dst.Delivery.Options[k] = v
+		}
 	}
 
 	return dst

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -358,7 +358,10 @@ func TestLoadSharedServerConfig(t *testing.T) {
 	content := `
 [server]
 hostname = "shared.example.com"
-maildir = "/var/mail"
+
+[server.delivery]
+type = "maildir"
+base_path = "/var/mail"
 
 [server.tls]
 cert_file = "/etc/ssl/shared-cert.pem"
@@ -381,8 +384,12 @@ log_level = "warn"
 		t.Errorf("hostname = %q, want 'shared.example.com'", cfg.Hostname)
 	}
 
-	if cfg.Delivery.Maildir != "/var/mail" {
-		t.Errorf("delivery.maildir = %q, want '/var/mail'", cfg.Delivery.Maildir)
+	if cfg.Delivery.Type != "maildir" {
+		t.Errorf("delivery.type = %q, want 'maildir'", cfg.Delivery.Type)
+	}
+
+	if cfg.Delivery.BasePath != "/var/mail" {
+		t.Errorf("delivery.base_path = %q, want '/var/mail'", cfg.Delivery.BasePath)
 	}
 
 	if cfg.TLS.CertFile != "/etc/ssl/shared-cert.pem" {
@@ -403,7 +410,10 @@ func TestLoadSmtpdOverridesServer(t *testing.T) {
 	content := `
 [server]
 hostname = "shared.example.com"
-maildir = "/var/mail"
+
+[server.delivery]
+type = "maildir"
+base_path = "/var/mail"
 
 [server.tls]
 cert_file = "/etc/ssl/shared-cert.pem"
@@ -416,7 +426,8 @@ hostname = "smtp.example.com"
 cert_file = "/etc/ssl/smtp-cert.pem"
 
 [smtpd.delivery]
-maildir = "/var/smtpmail"
+type = "maildir"
+base_path = "/var/smtpmail"
 `
 
 	path := createTempConfig(t, content)
@@ -431,8 +442,8 @@ maildir = "/var/smtpmail"
 		t.Errorf("hostname = %q, want 'smtp.example.com' (smtpd should override server)", cfg.Hostname)
 	}
 
-	if cfg.Delivery.Maildir != "/var/smtpmail" {
-		t.Errorf("delivery.maildir = %q, want '/var/smtpmail' (smtpd should override server)", cfg.Delivery.Maildir)
+	if cfg.Delivery.BasePath != "/var/smtpmail" {
+		t.Errorf("delivery.base_path = %q, want '/var/smtpmail' (smtpd should override server)", cfg.Delivery.BasePath)
 	}
 
 	if cfg.TLS.CertFile != "/etc/ssl/smtp-cert.pem" {


### PR DESCRIPTION
## Summary

- Replace direct dependency on `infodancer/maildir` with `infodancer/msgstore` registry/factory pattern
- Update `DeliveryConfig` to use generic `Type`, `BasePath`, and `Options` fields
- Use `msgstore.Open()` to create delivery agents from configuration
- Import `msgstore/maildir` as blank import for auto-registration via `init()`
- Update CLI flags from `-maildir` to `-delivery-type` and `-delivery-path`

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] Build succeeds (`go build ./...`)
- [ ] Manual test: run server with `-delivery-type maildir -delivery-path /tmp/mail`

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)