### PR TITLE
Add generic spam checker interface with rspamd implementation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -54,21 +54,24 @@ This document tracks the implementation status of SMTP commands, extensions, and
 
 ## Anti-Spam & Filtering
 
-### Email Authentication
-- [ ] SPF verification (RFC 7208)
-- [ ] DKIM verification (RFC 6376)
-- [ ] DMARC policy enforcement (RFC 7489)
-- [ ] ARC verification (RFC 8617)
-
-### Reputation Systems
-- [ ] RBL/DNSBL lookups
-- [ ] Greylisting
-- [ ] Sender reputation tracking
-
-### Content Filtering
-- [ ] Milter support (Sendmail milter protocol)
+### Spam Checker Integration
+- [x] Generic spam checker interface (pluggable backends)
+- [x] rspamd integration via HTTP API
 - [ ] SpamAssassin integration via spamc
-- [ ] ClamAV integration via clamd
+
+### Via rspamd (when rspamd is configured)
+The following are handled by rspamd when enabled:
+- [x] SPF verification (RFC 7208)
+- [x] DKIM verification (RFC 6376)
+- [x] DMARC policy enforcement (RFC 7489)
+- [x] ARC verification (RFC 8617)
+- [x] RBL/DNSBL lookups
+- [x] Greylisting
+- [x] Sender reputation tracking
+- [x] ClamAV/antivirus integration (via rspamd antivirus module)
+
+### Native Features (not yet implemented)
+- [ ] Milter support (Sendmail milter protocol)
 - [ ] Custom filter hooks
 
 ### Rate Limiting
@@ -103,7 +106,7 @@ This document tracks the implementation status of SMTP commands, extensions, and
 - [x] Message metrics (received, rejected by reason)
 - [x] Authentication metrics (attempts by mechanism/result)
 - [x] Command processing metrics
-- [x] Anti-spam metric hooks (SPF, DKIM, DMARC, RBL)
+- [x] Spam check metrics (score, result)
 - [x] Delivery metrics
 
 ### Logging (Implemented)
@@ -118,6 +121,7 @@ This document tracks the implementation status of SMTP commands, extensions, and
 - [x] DeliveryAgent interface for message delivery
 - [x] AuthenticationAgent interface for authentication
 - [x] Metrics interface with hooks for extensions
+- [x] SpamChecker interface for pluggable spam filtering
 
 ### Listener Modes (Implemented)
 - [x] SMTP mode (port 25)

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -67,6 +67,9 @@ func Load(path string) (Config, error) {
 	// Then merge smtpd-specific config (takes precedence)
 	cfg = mergeConfig(cfg, fileConfig.Smtpd)
 
+	// Merge top-level spamcheck config (shared across services)
+	cfg = mergeSpamCheckConfig(cfg, fileConfig.SpamCheck)
+
 	return cfg, nil
 }
 
@@ -257,5 +260,34 @@ func mergeConfig(dst, src Config) Config {
 		}
 	}
 
+	// Merge spamcheck config (if defined in [smtpd.spamcheck])
+	dst = mergeSpamCheckConfig(dst, src.SpamCheck)
+
+	return dst
+}
+
+// mergeSpamCheckConfig merges spamcheck settings into the config.
+func mergeSpamCheckConfig(dst Config, src SpamCheckConfig) Config {
+	if src.Enabled {
+		dst.SpamCheck.Enabled = src.Enabled
+	}
+	if len(src.Checkers) > 0 {
+		dst.SpamCheck.Checkers = src.Checkers
+	}
+	if src.Mode != "" {
+		dst.SpamCheck.Mode = src.Mode
+	}
+	if src.FailMode != "" {
+		dst.SpamCheck.FailMode = src.FailMode
+	}
+	if src.RejectThreshold != 0 {
+		dst.SpamCheck.RejectThreshold = src.RejectThreshold
+	}
+	if src.TempFailThreshold != 0 {
+		dst.SpamCheck.TempFailThreshold = src.TempFailThreshold
+	}
+	if src.AddHeaders {
+		dst.SpamCheck.AddHeaders = src.AddHeaders
+	}
 	return dst
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -31,6 +31,10 @@ type Collector interface {
 	DKIMCheckCompleted(senderDomain string, result string)
 	DMARCCheckCompleted(senderDomain string, result string)
 	RBLHit(listName string) // IP-based, no domain
+
+	// Rspamd metrics
+	// result should be "ham", "spam", "soft_reject", "greylist", or "error"
+	RspamdCheckCompleted(senderDomain string, result string, score float64)
 }
 
 // Server defines the interface for a metrics HTTP server.

--- a/internal/metrics/noop.go
+++ b/internal/metrics/noop.go
@@ -39,3 +39,6 @@ func (n *NoopCollector) DMARCCheckCompleted(senderDomain string, result string) 
 
 // RBLHit is a no-op.
 func (n *NoopCollector) RBLHit(listName string) {}
+
+// RspamdCheckCompleted is a no-op.
+func (n *NoopCollector) RspamdCheckCompleted(senderDomain string, result string, score float64) {}

--- a/internal/rspamd/client.go
+++ b/internal/rspamd/client.go
@@ -1,0 +1,262 @@
+// Package rspamd provides a spam checker implementation using rspamd.
+package rspamd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/infodancer/smtpd/internal/spamcheck"
+)
+
+// RspamdAction represents the action from rspamd's response.
+type RspamdAction string
+
+const (
+	// RspamdActionNoAction means the message should be delivered normally.
+	RspamdActionNoAction RspamdAction = "no action"
+	// RspamdActionGreylist means the message should be greylisted.
+	RspamdActionGreylist RspamdAction = "greylist"
+	// RspamdActionAddHeader means spam headers should be added.
+	RspamdActionAddHeader RspamdAction = "add header"
+	// RspamdActionRewriteSubject means the subject should be rewritten.
+	RspamdActionRewriteSubject RspamdAction = "rewrite subject"
+	// RspamdActionSoftReject means temporary rejection (4xx).
+	RspamdActionSoftReject RspamdAction = "soft reject"
+	// RspamdActionReject means permanent rejection (5xx).
+	RspamdActionReject RspamdAction = "reject"
+)
+
+// RspamdResult represents the raw result from rspamd.
+type RspamdResult struct {
+	Score         float64                  `json:"score"`
+	RequiredScore float64                  `json:"required_score"`
+	Action        RspamdAction             `json:"action"`
+	IsSpam        bool                     `json:"is_spam"`
+	Subject       string                   `json:"subject,omitempty"`
+	Symbols       map[string]SymbolResult  `json:"symbols,omitempty"`
+	URLs          []string                 `json:"urls,omitempty"`
+	Emails        []string                 `json:"emails,omitempty"`
+	MessageID     string                   `json:"message-id,omitempty"`
+	DKIMSig       string                   `json:"dkim-signature,omitempty"`
+	Milter        *MilterResult            `json:"milter,omitempty"`
+}
+
+// SymbolResult represents a matched rule/symbol.
+type SymbolResult struct {
+	Name        string   `json:"name"`
+	Score       float64  `json:"score"`
+	MetricScore float64  `json:"metric_score,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Options     []string `json:"options,omitempty"`
+}
+
+// MilterResult contains milter-specific headers to add/modify.
+type MilterResult struct {
+	AddHeaders    map[string]HeaderValue `json:"add_headers,omitempty"`
+	RemoveHeaders map[string]int         `json:"remove_headers,omitempty"`
+}
+
+// HeaderValue represents a header value with optional order.
+type HeaderValue struct {
+	Value string `json:"value"`
+	Order int    `json:"order,omitempty"`
+}
+
+// Checker implements spamcheck.Checker using rspamd.
+type Checker struct {
+	baseURL    string
+	password   string
+	httpClient *http.Client
+}
+
+// NewChecker creates a new rspamd checker.
+func NewChecker(baseURL string, password string, timeout time.Duration) *Checker {
+	return &Checker{
+		baseURL:  strings.TrimSuffix(baseURL, "/"),
+		password: password,
+		httpClient: &http.Client{
+			Timeout: timeout,
+		},
+	}
+}
+
+// Name returns the name of this checker.
+func (c *Checker) Name() string {
+	return "rspamd"
+}
+
+// Check performs a spam check using rspamd.
+func (c *Checker) Check(ctx context.Context, message io.Reader, opts spamcheck.CheckOptions) (*spamcheck.CheckResult, error) {
+	// Read message into buffer for the request
+	msgData, err := io.ReadAll(message)
+	if err != nil {
+		return nil, fmt.Errorf("reading message: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/checkv2", bytes.NewReader(msgData))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	// Set required headers
+	req.Header.Set("Content-Type", "text/plain")
+
+	if opts.From != "" {
+		req.Header.Set("From", opts.From)
+	}
+
+	for _, rcpt := range opts.Recipients {
+		req.Header.Add("Rcpt", rcpt)
+	}
+
+	if opts.IP != "" {
+		req.Header.Set("IP", opts.IP)
+	}
+
+	if opts.Helo != "" {
+		req.Header.Set("Helo", opts.Helo)
+	}
+
+	if opts.Hostname != "" {
+		req.Header.Set("Hostname", opts.Hostname)
+	}
+
+	if opts.User != "" {
+		req.Header.Set("User", opts.User)
+	}
+
+	if opts.QueueID != "" {
+		req.Header.Set("Queue-Id", opts.QueueID)
+	}
+
+	if c.password != "" {
+		req.Header.Set("Password", c.password)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("sending request: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("rspamd returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var rspamdResult RspamdResult
+	if err := json.NewDecoder(resp.Body).Decode(&rspamdResult); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+
+	return c.convertResult(&rspamdResult), nil
+}
+
+// convertResult converts an rspamd result to a generic CheckResult.
+func (c *Checker) convertResult(r *RspamdResult) *spamcheck.CheckResult {
+	result := &spamcheck.CheckResult{
+		CheckerName: "rspamd",
+		Score:       r.Score,
+		IsSpam:      r.IsSpam,
+		Headers:     c.buildHeaders(r),
+		Details: map[string]interface{}{
+			"required_score": r.RequiredScore,
+			"rspamd_action":  r.Action,
+		},
+	}
+
+	// Convert rspamd action to generic action
+	switch r.Action {
+	case RspamdActionReject:
+		result.Action = spamcheck.ActionReject
+		result.RejectMessage = fmt.Sprintf("Message rejected as spam (score %.1f)", r.Score)
+	case RspamdActionSoftReject, RspamdActionGreylist:
+		result.Action = spamcheck.ActionTempFail
+		result.RejectMessage = "Message deferred, please try again later"
+	case RspamdActionAddHeader, RspamdActionRewriteSubject:
+		result.Action = spamcheck.ActionFlag
+	default:
+		result.Action = spamcheck.ActionAccept
+	}
+
+	return result
+}
+
+// buildHeaders creates X-Spam-* headers from rspamd result.
+func (c *Checker) buildHeaders(r *RspamdResult) map[string]string {
+	headers := make(map[string]string)
+
+	// X-Spam-Status
+	status := "No"
+	if r.IsSpam {
+		status = "Yes"
+	}
+	headers["X-Spam-Status"] = fmt.Sprintf("%s, score=%.2f required=%.2f", status, r.Score, r.RequiredScore)
+
+	// X-Spam-Score
+	headers["X-Spam-Score"] = fmt.Sprintf("%.2f", r.Score)
+
+	// X-Spam-Flag
+	if r.IsSpam {
+		headers["X-Spam-Flag"] = "YES"
+	} else {
+		headers["X-Spam-Flag"] = "NO"
+	}
+
+	// X-Spam-Checker
+	headers["X-Spam-Checker"] = "rspamd"
+
+	// If milter headers are present, add them
+	if r.Milter != nil {
+		for name, hv := range r.Milter.AddHeaders {
+			// Skip headers we already set
+			if !strings.HasPrefix(strings.ToLower(name), "x-spam-") {
+				headers[name] = hv.Value
+			}
+		}
+	}
+
+	return headers
+}
+
+// Close releases resources (no-op for rspamd as it uses HTTP).
+func (c *Checker) Close() error {
+	return nil
+}
+
+// Ping checks if rspamd is available.
+func (c *Checker) Ping(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/ping", nil)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+
+	if c.password != "" {
+		req.Header.Set("Password", c.password)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("sending request: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("rspamd returned status %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+// Ensure Checker implements spamcheck.Checker
+var _ spamcheck.Checker = (*Checker)(nil)

--- a/internal/rspamd/client_test.go
+++ b/internal/rspamd/client_test.go
@@ -1,0 +1,405 @@
+package rspamd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/infodancer/smtpd/internal/spamcheck"
+)
+
+func TestNewChecker(t *testing.T) {
+	checker := NewChecker("http://localhost:11333", "secret", 10*time.Second)
+
+	if checker.baseURL != "http://localhost:11333" {
+		t.Errorf("expected baseURL http://localhost:11333, got %s", checker.baseURL)
+	}
+	if checker.password != "secret" {
+		t.Errorf("expected password secret, got %s", checker.password)
+	}
+	if checker.httpClient.Timeout != 10*time.Second {
+		t.Errorf("expected timeout 10s, got %v", checker.httpClient.Timeout)
+	}
+}
+
+func TestNewChecker_TrimsTrailingSlash(t *testing.T) {
+	checker := NewChecker("http://localhost:11333/", "", 10*time.Second)
+
+	if checker.baseURL != "http://localhost:11333" {
+		t.Errorf("expected baseURL without trailing slash, got %s", checker.baseURL)
+	}
+}
+
+func TestChecker_Name(t *testing.T) {
+	checker := NewChecker("http://localhost:11333", "", 10*time.Second)
+	if checker.Name() != "rspamd" {
+		t.Errorf("expected name 'rspamd', got %s", checker.Name())
+	}
+}
+
+func TestChecker_Check(t *testing.T) {
+	tests := []struct {
+		name           string
+		response       RspamdResult
+		statusCode     int
+		wantErr        bool
+		expectedScore  float64
+		expectedAction spamcheck.Action
+	}{
+		{
+			name: "ham message",
+			response: RspamdResult{
+				Score:         1.5,
+				RequiredScore: 15.0,
+				Action:        RspamdActionNoAction,
+				IsSpam:        false,
+			},
+			statusCode:     http.StatusOK,
+			wantErr:        false,
+			expectedScore:  1.5,
+			expectedAction: spamcheck.ActionAccept,
+		},
+		{
+			name: "spam message",
+			response: RspamdResult{
+				Score:         20.5,
+				RequiredScore: 15.0,
+				Action:        RspamdActionReject,
+				IsSpam:        true,
+			},
+			statusCode:     http.StatusOK,
+			wantErr:        false,
+			expectedScore:  20.5,
+			expectedAction: spamcheck.ActionReject,
+		},
+		{
+			name: "greylist message",
+			response: RspamdResult{
+				Score:         5.0,
+				RequiredScore: 15.0,
+				Action:        RspamdActionGreylist,
+				IsSpam:        false,
+			},
+			statusCode:     http.StatusOK,
+			wantErr:        false,
+			expectedScore:  5.0,
+			expectedAction: spamcheck.ActionTempFail,
+		},
+		{
+			name: "soft reject message",
+			response: RspamdResult{
+				Score:         8.0,
+				RequiredScore: 15.0,
+				Action:        RspamdActionSoftReject,
+				IsSpam:        false,
+			},
+			statusCode:     http.StatusOK,
+			wantErr:        false,
+			expectedScore:  8.0,
+			expectedAction: spamcheck.ActionTempFail,
+		},
+		{
+			name: "add header message",
+			response: RspamdResult{
+				Score:         10.0,
+				RequiredScore: 15.0,
+				Action:        RspamdActionAddHeader,
+				IsSpam:        false,
+			},
+			statusCode:     http.StatusOK,
+			wantErr:        false,
+			expectedScore:  10.0,
+			expectedAction: spamcheck.ActionFlag,
+		},
+		{
+			name:       "server error",
+			statusCode: http.StatusInternalServerError,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/checkv2" {
+					t.Errorf("expected path /checkv2, got %s", r.URL.Path)
+				}
+				if r.Method != http.MethodPost {
+					t.Errorf("expected POST, got %s", r.Method)
+				}
+
+				w.WriteHeader(tt.statusCode)
+				if tt.statusCode == http.StatusOK {
+					if err := json.NewEncoder(w).Encode(tt.response); err != nil {
+						t.Fatalf("failed to encode response: %v", err)
+					}
+				}
+			}))
+			defer server.Close()
+
+			checker := NewChecker(server.URL, "", 10*time.Second)
+			result, err := checker.Check(context.Background(), strings.NewReader("test message"), spamcheck.CheckOptions{
+				From:       "sender@example.com",
+				Recipients: []string{"recipient@example.com"},
+				IP:         "192.168.1.1",
+				Helo:       "client.example.com",
+			})
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if result.Score != tt.expectedScore {
+				t.Errorf("expected score %.2f, got %.2f", tt.expectedScore, result.Score)
+			}
+			if result.Action != tt.expectedAction {
+				t.Errorf("expected action %s, got %s", tt.expectedAction, result.Action)
+			}
+			if result.CheckerName != "rspamd" {
+				t.Errorf("expected checker name 'rspamd', got %s", result.CheckerName)
+			}
+		})
+	}
+}
+
+func TestChecker_Check_Headers(t *testing.T) {
+	var receivedHeaders http.Header
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeaders = r.Header
+
+		w.WriteHeader(http.StatusOK)
+		if err := json.NewEncoder(w).Encode(RspamdResult{Score: 1.0, Action: RspamdActionNoAction}); err != nil {
+			t.Fatalf("failed to encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	checker := NewChecker(server.URL, "testpass", 10*time.Second)
+	_, err := checker.Check(context.Background(), strings.NewReader("test"), spamcheck.CheckOptions{
+		From:       "sender@example.com",
+		Recipients: []string{"rcpt1@example.com", "rcpt2@example.com"},
+		IP:         "10.0.0.1",
+		Helo:       "mail.example.com",
+		Hostname:   "server.example.com",
+		User:       "testuser",
+		QueueID:    "ABC123",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Check headers were set correctly
+	if receivedHeaders.Get("From") != "sender@example.com" {
+		t.Errorf("expected From header sender@example.com, got %s", receivedHeaders.Get("From"))
+	}
+	if receivedHeaders.Get("IP") != "10.0.0.1" {
+		t.Errorf("expected IP header 10.0.0.1, got %s", receivedHeaders.Get("IP"))
+	}
+	if receivedHeaders.Get("Helo") != "mail.example.com" {
+		t.Errorf("expected Helo header mail.example.com, got %s", receivedHeaders.Get("Helo"))
+	}
+	if receivedHeaders.Get("Hostname") != "server.example.com" {
+		t.Errorf("expected Hostname header server.example.com, got %s", receivedHeaders.Get("Hostname"))
+	}
+	if receivedHeaders.Get("User") != "testuser" {
+		t.Errorf("expected User header testuser, got %s", receivedHeaders.Get("User"))
+	}
+	if receivedHeaders.Get("Queue-Id") != "ABC123" {
+		t.Errorf("expected Queue-Id header ABC123, got %s", receivedHeaders.Get("Queue-Id"))
+	}
+	if receivedHeaders.Get("Password") != "testpass" {
+		t.Errorf("expected Password header testpass, got %s", receivedHeaders.Get("Password"))
+	}
+
+	// Check multiple recipients
+	rcpts := receivedHeaders.Values("Rcpt")
+	if len(rcpts) != 2 {
+		t.Errorf("expected 2 Rcpt headers, got %d", len(rcpts))
+	}
+}
+
+func TestChecker_Ping(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		wantErr    bool
+	}{
+		{
+			name:       "success",
+			statusCode: http.StatusOK,
+			wantErr:    false,
+		},
+		{
+			name:       "server error",
+			statusCode: http.StatusInternalServerError,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/ping" {
+					t.Errorf("expected path /ping, got %s", r.URL.Path)
+				}
+				w.WriteHeader(tt.statusCode)
+			}))
+			defer server.Close()
+
+			checker := NewChecker(server.URL, "", 10*time.Second)
+			err := checker.Ping(context.Background())
+
+			if tt.wantErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestChecker_Close(t *testing.T) {
+	checker := NewChecker("http://localhost:11333", "", 10*time.Second)
+	err := checker.Close()
+	if err != nil {
+		t.Errorf("expected no error from Close(), got %v", err)
+	}
+}
+
+func TestCheckResult_ShouldReject(t *testing.T) {
+	tests := []struct {
+		name      string
+		result    spamcheck.CheckResult
+		threshold float64
+		want      bool
+	}{
+		{
+			name:      "action reject",
+			result:    spamcheck.CheckResult{Action: spamcheck.ActionReject, Score: 10.0},
+			threshold: 15.0,
+			want:      true,
+		},
+		{
+			name:      "score above threshold",
+			result:    spamcheck.CheckResult{Action: spamcheck.ActionAccept, Score: 20.0},
+			threshold: 15.0,
+			want:      true,
+		},
+		{
+			name:      "score below threshold",
+			result:    spamcheck.CheckResult{Action: spamcheck.ActionAccept, Score: 5.0},
+			threshold: 15.0,
+			want:      false,
+		},
+		{
+			name:      "threshold disabled",
+			result:    spamcheck.CheckResult{Action: spamcheck.ActionAccept, Score: 20.0},
+			threshold: 0,
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.result.ShouldReject(tt.threshold); got != tt.want {
+				t.Errorf("ShouldReject() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCheckResult_ShouldTempFail(t *testing.T) {
+	tests := []struct {
+		name      string
+		result    spamcheck.CheckResult
+		threshold float64
+		want      bool
+	}{
+		{
+			name:      "action tempfail",
+			result:    spamcheck.CheckResult{Action: spamcheck.ActionTempFail, Score: 5.0},
+			threshold: 10.0,
+			want:      true,
+		},
+		{
+			name:      "score above threshold",
+			result:    spamcheck.CheckResult{Action: spamcheck.ActionAccept, Score: 12.0},
+			threshold: 10.0,
+			want:      true,
+		},
+		{
+			name:      "score below threshold",
+			result:    spamcheck.CheckResult{Action: spamcheck.ActionAccept, Score: 5.0},
+			threshold: 10.0,
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.result.ShouldTempFail(tt.threshold); got != tt.want {
+				t.Errorf("ShouldTempFail() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestChecker_BuildHeaders(t *testing.T) {
+	checker := NewChecker("http://localhost:11333", "", 10*time.Second)
+
+	t.Run("spam message headers", func(t *testing.T) {
+		result := &RspamdResult{
+			Score:         15.5,
+			RequiredScore: 15.0,
+			Action:        RspamdActionReject,
+			IsSpam:        true,
+		}
+
+		headers := checker.buildHeaders(result)
+
+		if headers["X-Spam-Status"] != "Yes, score=15.50 required=15.00" {
+			t.Errorf("unexpected X-Spam-Status: %s", headers["X-Spam-Status"])
+		}
+		if headers["X-Spam-Score"] != "15.50" {
+			t.Errorf("unexpected X-Spam-Score: %s", headers["X-Spam-Score"])
+		}
+		if headers["X-Spam-Flag"] != "YES" {
+			t.Errorf("unexpected X-Spam-Flag: %s", headers["X-Spam-Flag"])
+		}
+		if headers["X-Spam-Checker"] != "rspamd" {
+			t.Errorf("unexpected X-Spam-Checker: %s", headers["X-Spam-Checker"])
+		}
+	})
+
+	t.Run("ham message headers", func(t *testing.T) {
+		result := &RspamdResult{
+			Score:         2.5,
+			RequiredScore: 15.0,
+			Action:        RspamdActionNoAction,
+			IsSpam:        false,
+		}
+
+		headers := checker.buildHeaders(result)
+
+		if headers["X-Spam-Status"] != "No, score=2.50 required=15.00" {
+			t.Errorf("unexpected X-Spam-Status: %s", headers["X-Spam-Status"])
+		}
+		if headers["X-Spam-Flag"] != "NO" {
+			t.Errorf("unexpected X-Spam-Flag: %s", headers["X-Spam-Flag"])
+		}
+	})
+}

--- a/internal/smtp/handler_integration_test.go
+++ b/internal/smtp/handler_integration_test.go
@@ -46,7 +46,7 @@ func startTestServer(t *testing.T, delivery *smtpd.MockDeliveryAgent) (string, f
 		t.Fatalf("failed to create server: %v", err)
 	}
 
-	handler := smtp.Handler("test.example.com", nil, delivery, nil, nil)
+	handler := smtp.Handler("test.example.com", nil, delivery, nil, nil, nil)
 	srv.SetHandler(handler)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/smtp/handler_test.go
+++ b/internal/smtp/handler_test.go
@@ -163,7 +163,7 @@ func TestHandlerGreeting(t *testing.T) {
 	mc, conn := createTestConnection("QUIT\r\n")
 	ctx := createTestContext()
 
-	handler := Handler("mail.example.com", nil, nil, nil, nil)
+	handler := Handler("mail.example.com", nil, nil, nil, nil, nil)
 	handler(ctx, conn)
 
 	output := mc.writeData.String()
@@ -176,7 +176,7 @@ func TestHandlerEHLO(t *testing.T) {
 	mc, conn := createTestConnection("EHLO client.example.com\r\nQUIT\r\n")
 	ctx := createTestContext()
 
-	handler := Handler("mail.example.com", nil, nil, nil, nil)
+	handler := Handler("mail.example.com", nil, nil, nil, nil, nil)
 	handler(ctx, conn)
 
 	output := mc.writeData.String()
@@ -203,7 +203,7 @@ func TestHandlerHELO(t *testing.T) {
 	mc, conn := createTestConnection("HELO client.example.com\r\nQUIT\r\n")
 	ctx := createTestContext()
 
-	handler := Handler("mail.example.com", nil, nil, nil, nil)
+	handler := Handler("mail.example.com", nil, nil, nil, nil, nil)
 	handler(ctx, conn)
 
 	output := mc.writeData.String()
@@ -220,7 +220,7 @@ func TestHandlerBadSequence(t *testing.T) {
 	mc, conn := createTestConnection("MAIL FROM:<sender@example.com>\r\nQUIT\r\n")
 	ctx := createTestContext()
 
-	handler := Handler("mail.example.com", nil, nil, nil, nil)
+	handler := Handler("mail.example.com", nil, nil, nil, nil, nil)
 	handler(ctx, conn)
 
 	output := mc.writeData.String()
@@ -236,7 +236,7 @@ func TestHandlerUnknownCommand(t *testing.T) {
 	mc, conn := createTestConnection("EHLO test.example\r\nFOOBAR\r\nQUIT\r\n")
 	ctx := createTestContext()
 
-	handler := Handler("mail.example.com", nil, nil, nil, nil)
+	handler := Handler("mail.example.com", nil, nil, nil, nil, nil)
 	handler(ctx, conn)
 
 	output := mc.writeData.String()
@@ -264,7 +264,7 @@ func TestHandlerFullTransaction(t *testing.T) {
 	ctx := createTestContext()
 
 	delivery := &mockDeliveryAgent{}
-	handler := Handler("mail.example.com", nil, delivery, nil, nil)
+	handler := Handler("mail.example.com", nil, delivery, nil, nil, nil)
 	handler(ctx, conn)
 
 	output := mc.writeData.String()
@@ -326,7 +326,7 @@ func TestHandlerDotStuffing(t *testing.T) {
 	ctx := createTestContext()
 
 	delivery := &mockDeliveryAgent{}
-	handler := Handler("mail.example.com", nil, delivery, nil, nil)
+	handler := Handler("mail.example.com", nil, delivery, nil, nil, nil)
 	handler(ctx, conn)
 
 	_ = mc // suppress unused warning
@@ -353,7 +353,7 @@ func TestHandlerRSET(t *testing.T) {
 	mc, conn := createTestConnection(input)
 	ctx := createTestContext()
 
-	handler := Handler("mail.example.com", nil, nil, nil, nil)
+	handler := Handler("mail.example.com", nil, nil, nil, nil, nil)
 	handler(ctx, conn)
 
 	output := mc.writeData.String()
@@ -368,7 +368,7 @@ func TestHandlerNOOP(t *testing.T) {
 	mc, conn := createTestConnection("EHLO test.example\r\nNOOP\r\nNOOP with params\r\nQUIT\r\n")
 	ctx := createTestContext()
 
-	handler := Handler("mail.example.com", nil, nil, nil, nil)
+	handler := Handler("mail.example.com", nil, nil, nil, nil, nil)
 	handler(ctx, conn)
 
 	output := mc.writeData.String()
@@ -397,7 +397,7 @@ func TestHandlerMetrics(t *testing.T) {
 
 	collector := &mockCollector{}
 	delivery := &mockDeliveryAgent{}
-	handler := Handler("mail.example.com", collector, delivery, nil, nil)
+	handler := Handler("mail.example.com", collector, delivery, nil, nil, nil)
 	handler(ctx, conn)
 
 	if collector.connectionsOpened != 1 {
@@ -433,7 +433,7 @@ func TestHandlerNoDeliveryAgent(t *testing.T) {
 	mc, conn := createTestConnection(input)
 	ctx := createTestContext()
 
-	handler := Handler("mail.example.com", nil, nil, nil, nil)
+	handler := Handler("mail.example.com", nil, nil, nil, nil, nil)
 	handler(ctx, conn)
 
 	output := mc.writeData.String()
@@ -462,7 +462,7 @@ func TestHandlerDeliveryError(t *testing.T) {
 
 	delivery := &mockDeliveryAgent{shouldError: true}
 	collector := &mockCollector{}
-	handler := Handler("mail.example.com", collector, delivery, nil, nil)
+	handler := Handler("mail.example.com", collector, delivery, nil, nil, nil)
 	handler(ctx, conn)
 
 	output := mc.writeData.String()
@@ -482,7 +482,7 @@ func TestHandlerQUITResponse(t *testing.T) {
 	mc, conn := createTestConnection("QUIT\r\n")
 	ctx := createTestContext()
 
-	handler := Handler("mail.example.com", nil, nil, nil, nil)
+	handler := Handler("mail.example.com", nil, nil, nil, nil, nil)
 	handler(ctx, conn)
 
 	output := mc.writeData.String()

--- a/internal/spamcheck/multi.go
+++ b/internal/spamcheck/multi.go
@@ -1,0 +1,270 @@
+package spamcheck
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+)
+
+// MultiChecker runs multiple spam checkers and aggregates results.
+type MultiChecker struct {
+	checkers []Checker
+	config   MultiConfig
+}
+
+// MultiConfig holds configuration for the multi-checker.
+type MultiConfig struct {
+	// Mode determines how results are aggregated.
+	// "first_reject" - reject if any checker says reject (default)
+	// "all_reject" - reject only if all checkers say reject
+	// "highest_score" - use the result with the highest score
+	Mode string
+
+	// FailMode determines behavior when a checker errors.
+	FailMode FailMode
+
+	// RejectThreshold is the score threshold for rejection.
+	RejectThreshold float64
+
+	// TempFailThreshold is the score threshold for temp failure.
+	TempFailThreshold float64
+
+	// AddHeaders indicates whether to add headers from all checkers.
+	AddHeaders bool
+}
+
+// NewMultiChecker creates a new multi-checker with the given checkers.
+func NewMultiChecker(checkers []Checker, config MultiConfig) *MultiChecker {
+	if config.Mode == "" {
+		config.Mode = "first_reject"
+	}
+	return &MultiChecker{
+		checkers: checkers,
+		config:   config,
+	}
+}
+
+// Name returns the name of this checker.
+func (m *MultiChecker) Name() string {
+	return "multi"
+}
+
+// Check runs all checkers and aggregates results.
+func (m *MultiChecker) Check(ctx context.Context, message io.Reader, opts CheckOptions) (*CheckResult, error) {
+	if len(m.checkers) == 0 {
+		return &CheckResult{
+			CheckerName: "multi",
+			Action:      ActionAccept,
+		}, nil
+	}
+
+	// Read message into buffer so we can pass it to multiple checkers
+	msgData, err := io.ReadAll(message)
+	if err != nil {
+		return nil, fmt.Errorf("reading message: %w", err)
+	}
+
+	var results []*CheckResult
+	var errors []error
+	aggregatedHeaders := make(map[string]string)
+
+	for _, checker := range m.checkers {
+		result, err := checker.Check(ctx, bytes.NewReader(msgData), opts)
+		if err != nil {
+			errors = append(errors, fmt.Errorf("%s: %w", checker.Name(), err))
+			continue
+		}
+		results = append(results, result)
+
+		// Collect headers from all checkers
+		if m.config.AddHeaders && result.Headers != nil {
+			for k, v := range result.Headers {
+				aggregatedHeaders[k] = v
+			}
+		}
+	}
+
+	// If all checkers errored, handle according to fail mode
+	if len(results) == 0 && len(errors) > 0 {
+		return nil, fmt.Errorf("all checkers failed: %v", errors)
+	}
+
+	// Aggregate results based on mode
+	finalResult := m.aggregateResults(results)
+	finalResult.Headers = aggregatedHeaders
+
+	return finalResult, nil
+}
+
+func (m *MultiChecker) aggregateResults(results []*CheckResult) *CheckResult {
+	if len(results) == 0 {
+		return &CheckResult{
+			CheckerName: "multi",
+			Action:      ActionAccept,
+		}
+	}
+
+	if len(results) == 1 {
+		return results[0]
+	}
+
+	switch m.config.Mode {
+	case "all_reject":
+		return m.aggregateAllReject(results)
+	case "highest_score":
+		return m.aggregateHighestScore(results)
+	default: // "first_reject"
+		return m.aggregateFirstReject(results)
+	}
+}
+
+// aggregateFirstReject returns reject if any checker says reject.
+func (m *MultiChecker) aggregateFirstReject(results []*CheckResult) *CheckResult {
+	var highestScore float64
+	var highestScoreResult *CheckResult
+
+	for _, r := range results {
+		// Return immediately if any checker says reject
+		if r.Action == ActionReject || r.ShouldReject(m.config.RejectThreshold) {
+			return &CheckResult{
+				CheckerName:   "multi",
+				Score:         r.Score,
+				Action:        ActionReject,
+				IsSpam:        true,
+				RejectMessage: r.RejectMessage,
+				Details: map[string]interface{}{
+					"rejected_by": r.CheckerName,
+					"score":       r.Score,
+				},
+			}
+		}
+
+		// Track highest score for final result
+		if r.Score > highestScore {
+			highestScore = r.Score
+			highestScoreResult = r
+		}
+	}
+
+	// Check for temp fail
+	for _, r := range results {
+		if r.Action == ActionTempFail || r.ShouldTempFail(m.config.TempFailThreshold) {
+			return &CheckResult{
+				CheckerName:   "multi",
+				Score:         r.Score,
+				Action:        ActionTempFail,
+				IsSpam:        false,
+				RejectMessage: r.RejectMessage,
+				Details: map[string]interface{}{
+					"tempfail_by": r.CheckerName,
+					"score":       r.Score,
+				},
+			}
+		}
+	}
+
+	// No rejection, return result with highest score
+	if highestScoreResult != nil {
+		return &CheckResult{
+			CheckerName: "multi",
+			Score:       highestScoreResult.Score,
+			Action:      ActionAccept,
+			IsSpam:      highestScoreResult.IsSpam,
+			Details: map[string]interface{}{
+				"highest_score_from": highestScoreResult.CheckerName,
+			},
+		}
+	}
+
+	return &CheckResult{
+		CheckerName: "multi",
+		Action:      ActionAccept,
+	}
+}
+
+// aggregateAllReject returns reject only if all checkers say reject.
+func (m *MultiChecker) aggregateAllReject(results []*CheckResult) *CheckResult {
+	allReject := true
+	var totalScore float64
+	var rejectMessage string
+
+	for _, r := range results {
+		totalScore += r.Score
+		if r.Action != ActionReject && !r.ShouldReject(m.config.RejectThreshold) {
+			allReject = false
+		}
+		if r.RejectMessage != "" {
+			rejectMessage = r.RejectMessage
+		}
+	}
+
+	avgScore := totalScore / float64(len(results))
+
+	if allReject {
+		return &CheckResult{
+			CheckerName:   "multi",
+			Score:         avgScore,
+			Action:        ActionReject,
+			IsSpam:        true,
+			RejectMessage: rejectMessage,
+		}
+	}
+
+	return &CheckResult{
+		CheckerName: "multi",
+		Score:       avgScore,
+		Action:      ActionAccept,
+		IsSpam:      false,
+	}
+}
+
+// aggregateHighestScore returns the result with the highest score.
+func (m *MultiChecker) aggregateHighestScore(results []*CheckResult) *CheckResult {
+	var highest *CheckResult
+
+	for _, r := range results {
+		if highest == nil || r.Score > highest.Score {
+			highest = r
+		}
+	}
+
+	if highest == nil {
+		return &CheckResult{
+			CheckerName: "multi",
+			Action:      ActionAccept,
+		}
+	}
+
+	action := ActionAccept
+	if highest.ShouldReject(m.config.RejectThreshold) {
+		action = ActionReject
+	} else if highest.ShouldTempFail(m.config.TempFailThreshold) {
+		action = ActionTempFail
+	}
+
+	return &CheckResult{
+		CheckerName:   "multi",
+		Score:         highest.Score,
+		Action:        action,
+		IsSpam:        highest.IsSpam,
+		RejectMessage: highest.RejectMessage,
+		Details: map[string]interface{}{
+			"highest_score_from": highest.CheckerName,
+		},
+	}
+}
+
+// Close closes all checkers.
+func (m *MultiChecker) Close() error {
+	var errs []error
+	for _, checker := range m.checkers {
+		if err := checker.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("errors closing checkers: %v", errs)
+	}
+	return nil
+}

--- a/internal/spamcheck/spamcheck.go
+++ b/internal/spamcheck/spamcheck.go
@@ -1,0 +1,142 @@
+// Package spamcheck provides a generic interface for spam filtering backends.
+package spamcheck
+
+import (
+	"context"
+	"io"
+)
+
+// Action represents the recommended action from a spam checker.
+type Action string
+
+const (
+	// ActionAccept means the message should be delivered normally.
+	ActionAccept Action = "accept"
+	// ActionReject means the message should be permanently rejected (5xx).
+	ActionReject Action = "reject"
+	// ActionTempFail means the message should be temporarily rejected (4xx).
+	ActionTempFail Action = "tempfail"
+	// ActionFlag means the message should be flagged but delivered.
+	ActionFlag Action = "flag"
+)
+
+// CheckOptions contains options for the spam check.
+type CheckOptions struct {
+	// From is the envelope sender (MAIL FROM).
+	From string
+
+	// Recipients is the list of envelope recipients (RCPT TO).
+	Recipients []string
+
+	// IP is the client IP address.
+	IP string
+
+	// Helo is the HELO/EHLO hostname.
+	Helo string
+
+	// Hostname is the server hostname.
+	Hostname string
+
+	// User is the authenticated username (if any).
+	User string
+
+	// QueueID is an optional queue ID for logging.
+	QueueID string
+}
+
+// CheckResult represents the result of a spam check.
+type CheckResult struct {
+	// CheckerName identifies which checker produced this result.
+	CheckerName string
+
+	// Score is the spam score (higher = more likely spam).
+	Score float64
+
+	// Action is the recommended action.
+	Action Action
+
+	// IsSpam indicates whether the checker considers this spam.
+	IsSpam bool
+
+	// Headers contains headers to add to the message (e.g., X-Spam-*).
+	Headers map[string]string
+
+	// RejectMessage is the message to send when rejecting (optional).
+	RejectMessage string
+
+	// Details contains checker-specific details for logging.
+	Details map[string]interface{}
+}
+
+// Checker is the interface for spam filtering backends.
+type Checker interface {
+	// Name returns the name of this checker for logging/metrics.
+	Name() string
+
+	// Check performs a spam check on the message.
+	// The message reader should be read completely; implementations may buffer it.
+	Check(ctx context.Context, message io.Reader, opts CheckOptions) (*CheckResult, error)
+
+	// Close releases any resources held by the checker.
+	Close() error
+}
+
+// FailMode defines the behavior when a spam checker is unavailable or errors.
+type FailMode string
+
+const (
+	// FailOpen accepts the message when the checker is unavailable.
+	FailOpen FailMode = "open"
+	// FailTempFail returns a temporary failure (4xx) when the checker is unavailable.
+	FailTempFail FailMode = "tempfail"
+	// FailReject returns a permanent failure (5xx) when the checker is unavailable.
+	FailReject FailMode = "reject"
+)
+
+// Config holds common configuration for spam checkers.
+type Config struct {
+	// FailMode determines behavior when the checker is unavailable.
+	FailMode FailMode
+
+	// RejectThreshold is the score at or above which messages are rejected (5xx).
+	RejectThreshold float64
+
+	// TempFailThreshold is the score at or above which messages get temp failure (4xx).
+	// Set to 0 to disable.
+	TempFailThreshold float64
+
+	// AddHeaders indicates whether to add spam headers to messages.
+	AddHeaders bool
+}
+
+// GetFailMode returns the fail mode, defaulting to tempfail if not set.
+func (c *Config) GetFailMode() FailMode {
+	switch c.FailMode {
+	case FailOpen, FailTempFail, FailReject:
+		return c.FailMode
+	default:
+		return FailTempFail
+	}
+}
+
+// ShouldReject returns true if the result indicates the message should be rejected.
+func (r *CheckResult) ShouldReject(threshold float64) bool {
+	if r.Action == ActionReject {
+		return true
+	}
+	if threshold > 0 && r.Score >= threshold {
+		return true
+	}
+	return false
+}
+
+// ShouldTempFail returns true if the result indicates a temporary failure.
+func (r *CheckResult) ShouldTempFail(threshold float64) bool {
+	if r.Action == ActionTempFail {
+		return true
+	}
+	if threshold > 0 && r.Score >= threshold {
+		return true
+	}
+	return false
+}

--- a/smtpd.toml.example
+++ b/smtpd.toml.example
@@ -35,6 +35,34 @@ mode = "submission"
 address = ":465"
 mode = "smtps"
 
+# Spam Check Configuration
+# Supports multiple spam checkers running in sequence
+# [spamcheck]
+# enabled = true
+# mode = "first_reject"          # "first_reject" | "all_reject" | "highest_score"
+#                                # first_reject = reject if any checker says reject
+#                                # all_reject = reject only if all checkers say reject
+#                                # highest_score = use result with highest score
+# fail_mode = "tempfail"         # "open" | "tempfail" | "reject"
+#                                # open = accept message if all checkers fail
+#                                # tempfail = 4xx error if all checkers fail
+#                                # reject = 5xx error if all checkers fail
+# reject_threshold = 15.0        # Score at or above which to reject (5xx)
+# tempfail_threshold = 0.0       # Score at or above which to defer (4xx), 0 = disabled
+# add_headers = false            # Add X-Spam-* headers to messages (default: false)
+#
+# [[spamcheck.checkers]]
+# type = "rspamd"
+# url = "http://localhost:11333"
+# password = ""                  # Optional controller password
+# timeout = "10s"
+#
+# # Example: add a second checker (when implemented)
+# # [[spamcheck.checkers]]
+# # type = "spamassassin"
+# # url = "localhost:783"
+# # timeout = "30s"
+
 # Future sections:
 # [pop3d]
 # [msgstore]


### PR DESCRIPTION
## Summary
- Add pluggable `spamcheck.Checker` interface for spam filtering backends
- Implement rspamd checker using HTTP API (`/checkv2` endpoint)
- Support multiple checkers with configurable aggregation modes (`first_reject`, `all_reject`, `highest_score`)
- Add configurable fail modes when checkers are unavailable (`open`, `tempfail`, `reject`)
- Update TODO.md to document features handled via rspamd (SPF, DKIM, DMARC, ARC, RBL, greylisting, reputation)

## Test plan
- [x] Unit tests for rspamd checker
- [x] All existing tests pass
- [x] Lint passes
- [ ] Manual testing with rspamd instance

Resolves #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)