### PR TITLE
Implement recipient domain validation with DomainProvider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,9 @@ toolchain go1.24.4
 require (
 	github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6
 	github.com/emersion/go-smtp v0.24.0
-	github.com/infodancer/auth v0.0.0-20260119190831-f30a740fec24
-	github.com/infodancer/msgstore v0.0.0-20260119122628-46a831f8f899
-	github.com/pelletier/go-toml/v2 v2.2.3
+	github.com/infodancer/auth v0.0.0-20260120022447-32c9d743aafb
+	github.com/infodancer/msgstore v0.0.0-20260119190950-8397c0fa98ca
+	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/prometheus/client_golang v1.23.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -11,10 +11,10 @@ github.com/emersion/go-smtp v0.24.0 h1:g6AfoF140mvW0vLNPD/LuCBLEAdlxOjIXqbIkJIS6
 github.com/emersion/go-smtp v0.24.0/go.mod h1:ZtRRkbTyp2XTHCA+BmyTFTrj8xY4I+b4McvHxCU2gsQ=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/infodancer/auth v0.0.0-20260119190831-f30a740fec24 h1:cYFx4wu+gHLt+wuz/3yUnvXktUTQehvl3NjmTBdAbCc=
-github.com/infodancer/auth v0.0.0-20260119190831-f30a740fec24/go.mod h1:KI3pKMQs3G2bLsYSttqIYiIvCORbDeekvb0/HzniZI4=
-github.com/infodancer/msgstore v0.0.0-20260119122628-46a831f8f899 h1:bxXLCWJbifXaherjSvcE5vLWlVJG67Xuqpo/Xxi6Wgc=
-github.com/infodancer/msgstore v0.0.0-20260119122628-46a831f8f899/go.mod h1:l8ooXfpt+UDDNSrg4IKQYglqRqIjp2Ei3GgOKdJVk00=
+github.com/infodancer/auth v0.0.0-20260120022447-32c9d743aafb h1:jAj8KfoneTlkt3RgbdQfYYa5gaHf/bifQPz1nIW1ysA=
+github.com/infodancer/auth v0.0.0-20260120022447-32c9d743aafb/go.mod h1:L4RUyYu+Mx0sUhXMxKRp+8qxJFPrur+cnI+8M2izaFQ=
+github.com/infodancer/msgstore v0.0.0-20260119190950-8397c0fa98ca h1:vFKaO6G7lV9nH9YcCUn3GKCiyy/0ZzRusbefOw/Mve0=
+github.com/infodancer/msgstore v0.0.0-20260119190950-8397c0fa98ca/go.mod h1:rAI37O/GFfseVCrMSVkZPQtLFgAuUctKRkEFAWGlutQ=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -25,8 +25,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
-github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
+github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
+github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,17 +39,18 @@ type ServerConfig struct {
 
 // Config holds the complete SMTP server configuration.
 type Config struct {
-	Hostname   string           `toml:"hostname"`
-	LogLevel   string           `toml:"log_level"`
-	Listeners  []ListenerConfig `toml:"listeners"`
-	TLS        TLSConfig        `toml:"tls"`
-	Limits     LimitsConfig     `toml:"limits"`
-	Timeouts   TimeoutsConfig   `toml:"timeouts"`
-	Metrics    MetricsConfig    `toml:"metrics"`
-	Delivery   DeliveryConfig   `toml:"delivery"`
-	Encryption EncryptionConfig `toml:"encryption"`
-	Auth       AuthConfig       `toml:"auth"`
-	SpamCheck  SpamCheckConfig  `toml:"spamcheck"`
+	Hostname    string           `toml:"hostname"`
+	LogLevel    string           `toml:"log_level"`
+	DomainsPath string           `toml:"domains_path"`
+	Listeners   []ListenerConfig `toml:"listeners"`
+	TLS         TLSConfig        `toml:"tls"`
+	Limits      LimitsConfig     `toml:"limits"`
+	Timeouts    TimeoutsConfig   `toml:"timeouts"`
+	Metrics     MetricsConfig    `toml:"metrics"`
+	Delivery    DeliveryConfig   `toml:"delivery"`
+	Encryption  EncryptionConfig `toml:"encryption"`
+	Auth        AuthConfig       `toml:"auth"`
+	SpamCheck   SpamCheckConfig  `toml:"spamcheck"`
 }
 
 // EncryptionConfig holds configuration for message encryption.

--- a/internal/smtp/backend.go
+++ b/internal/smtp/backend.go
@@ -8,6 +8,7 @@ import (
 	"github.com/infodancer/auth"
 	"github.com/infodancer/msgstore"
 	"github.com/infodancer/smtpd/internal/config"
+	"github.com/infodancer/auth/domain"
 	"github.com/infodancer/smtpd/internal/metrics"
 	"github.com/infodancer/smtpd/internal/spamcheck"
 )
@@ -18,6 +19,7 @@ type Backend struct {
 	hostname        string
 	delivery        msgstore.DeliveryAgent
 	authAgent       auth.AuthenticationAgent
+	domainProvider  domain.DomainProvider
 	spamChecker     spamcheck.Checker
 	spamConfig      config.SpamCheckConfig
 	collector       metrics.Collector
@@ -31,6 +33,7 @@ type BackendConfig struct {
 	Hostname       string
 	Delivery       msgstore.DeliveryAgent
 	AuthAgent      auth.AuthenticationAgent
+	DomainProvider domain.DomainProvider
 	SpamChecker    spamcheck.Checker
 	SpamConfig     config.SpamCheckConfig
 	Collector      metrics.Collector
@@ -50,6 +53,7 @@ func NewBackend(cfg BackendConfig) *Backend {
 		hostname:       cfg.Hostname,
 		delivery:       cfg.Delivery,
 		authAgent:      cfg.AuthAgent,
+		domainProvider: cfg.DomainProvider,
 		spamChecker:    cfg.SpamChecker,
 		spamConfig:     cfg.SpamConfig,
 		collector:      cfg.Collector,


### PR DESCRIPTION
## Summary
- Enforce single recipient per message to avoid partial delivery scenarios
- Validate recipient domain and user existence during RCPT TO
- Use `auth/domain.DomainProvider` for domain configuration
- Use domain-specific `DeliveryAgent` for message storage

## Changes
- Config: Add `domains_path` field for domain configuration directory
- Backend: Add `DomainProvider` field
- Session: Domain/user validation in `Rcpt()`, single recipient enforcement
- main.go: Create `FilesystemDomainProvider` when configured

## Test plan
- [x] All existing tests pass
- [ ] Unknown domain rejected with 550
- [ ] Unknown user rejected with 550
- [ ] Valid user accepted with 250
- [ ] Multiple RCPT TO rejected with 452
- [ ] Lookup failure returns 451

**Depends on:** https://github.com/infodancer/auth/pull/2

Related: https://github.com/infodancer/smtpd/issues/41

🤖 Generated with [Claude Code](https://claude.com/claude-code)