### PR TITLE
Fix CI and Dockerfile: strip replace directives for published modules

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -24,6 +24,10 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: stable
+      - name: Strip local replace directives and update checksums
+        run: |
+          go mod edit -dropreplace=github.com/infodancer/msgstore
+          go mod tidy
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:

--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -22,6 +22,10 @@ jobs:
           go-version: stable
       - name: Configure git for private modules
         run: git config --global url."https://x-access-token:${{ github.token }}@github.com/".insteadOf "https://github.com/"
+      - name: Strip local replace directives and update checksums
+        run: |
+          go mod edit -dropreplace=github.com/infodancer/msgstore
+          go mod tidy
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@
 FROM golang:1.24-alpine AS builder
 WORKDIR /build
 COPY go.mod go.sum ./
+# Strip local replace directives so Go fetches published module versions
+RUN go mod edit -dropreplace=github.com/infodancer/msgstore
 RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o smtpd ./cmd/smtpd


### PR DESCRIPTION
## Summary

- Add `go mod edit -dropreplace` + `go mod tidy` to CI workflows so lint and vulncheck resolve msgstore from the Go module proxy instead of expecting `../msgstore`
- Apply the same `go mod edit -dropreplace` fix to the Dockerfile builder stage
- Verified locally: strip + tidy succeeds, all tests pass

Closes #49

## Test plan

- [x] Local verification: `go mod edit -dropreplace` + `go mod tidy` succeeds
- [x] `go test ./...` passes
- [ ] CI lint passes
- [ ] CI vulncheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)