### PR TITLE
Fix DomainsPath silently dropped in config merge; harden session validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,12 +8,13 @@ require (
 	github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6
 	github.com/emersion/go-smtp v0.24.0
 	github.com/infodancer/auth v0.1.2
-	github.com/infodancer/msgstore v0.0.0-20260223102526-d345ec96dcb1
+	github.com/infodancer/msgstore v0.1.0
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/prometheus/client_golang v1.23.2
 )
 
 require (
+	git.sr.ht/~emersion/go-sieve v0.0.0-20240926192256-cf8e1a9b5da9 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+git.sr.ht/~emersion/go-sieve v0.0.0-20240926192256-cf8e1a9b5da9 h1:MaPyH1+nMX0azKxKQ+X6IiFWTlQokcKO5DKchAR9x5A=
+git.sr.ht/~emersion/go-sieve v0.0.0-20240926192256-cf8e1a9b5da9/go.mod h1:ewD6qhJ+zMwEeAElDEJOYYdkpxZSHRodJwq9Z0OG30w=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -20,8 +22,8 @@ github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/infodancer/auth v0.1.2 h1:F51ZBrjlecJ5v0WLJyzJcaDU6C/oDrHkORm5tpWl36g=
 github.com/infodancer/auth v0.1.2/go.mod h1:rMMSXMH8icBAACj40geMonedM5WBIcE1MUxvN9AJagg=
-github.com/infodancer/msgstore v0.0.0-20260223102526-d345ec96dcb1 h1:83r/zGAgg9zY294nw85nvWeMUbEojfowTd1pnqlzTQ8=
-github.com/infodancer/msgstore v0.0.0-20260223102526-d345ec96dcb1/go.mod h1:tYSPy8mPjYYamIdEoABTsx4wdUXESGrBJVnPIfy3lhY=
+github.com/infodancer/msgstore v0.1.0 h1:f4p/xxBUGgVE//iHWkJQw044gPaIf0JF9MxghTdCBKs=
+github.com/infodancer/msgstore v0.1.0/go.mod h1:koJxoBZnPilimtfw0lSOVmP7nF52ONdwcbgQjNuqci8=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=


### PR DESCRIPTION
## Summary

- **Bug fix**: `DomainsPath` was missing from `mergeConfig`, so `domains_path` set in `[smtpd]` config was silently dropped, leaving `domainProvider` nil at runtime. Added to `mergeConfig`, `ApplyFlags`, and `SMTPD_DOMAINS_PATH` env var support.
- **Bug fix**: Bounce rejection — `MAIL FROM:<>` (empty sender) was not correctly rejected; adds fail-early session validation.
- **Bug fix**: Internal error details were leaking to SMTP clients in error responses.
- **Test fix**: No-delivery-agent test corrected to expect 4xx (temporary/config error) rather than 5xx (permanent rejection).
- **Dependency**: Auth bumped to v0.1.2 (User.Mailbox normalization); msgstore bumped to v0.1.0.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] `TestLoadDomainsPath` regression test covers the mergeConfig fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)