### PR TITLE
Populate Envelope.SpamResult from spam check results

### DIFF
--- a/cmd/mail-deliver/main.go
+++ b/cmd/mail-deliver/main.go
@@ -19,10 +19,10 @@ import (
 	"syscall"
 	"time"
 
-	_ "github.com/infodancer/auth/passwd"
 	"github.com/infodancer/auth/domain"
-	_ "github.com/infodancer/msgstore/maildir"
+	_ "github.com/infodancer/auth/passwd"
 	"github.com/infodancer/msgstore"
+	_ "github.com/infodancer/msgstore/maildir"
 	"github.com/infodancer/smtpd/internal/config"
 	"github.com/infodancer/smtpd/internal/maildeliver"
 )
@@ -91,6 +91,13 @@ func run() error {
 	}
 	if req.ClientIP != "" {
 		envelope.ClientIP = net.ParseIP(req.ClientIP)
+	}
+	if req.SpamAction != "" {
+		envelope.SpamResult = &msgstore.SpamResult{
+			Score:   req.SpamScore,
+			Action:  req.SpamAction,
+			Checker: req.SpamChecker,
+		}
 	}
 
 	// Build global delivery agent from config (fallback when no per-domain config).

--- a/internal/maildeliver/wire.go
+++ b/internal/maildeliver/wire.go
@@ -25,4 +25,15 @@ type DeliverRequest struct {
 	// before writing to the maildir. This field is omitempty for backward
 	// compatibility. See: infodancer/infodancer/docs/encryption-design.md
 	EncryptionKeyHint string `json:"encryption_key_hint,omitempty"`
+
+	// SpamScore is the numeric spam score from the upstream checker.
+	// Zero means no spam check was performed or the message scored zero.
+	SpamScore float64 `json:"spam_score,omitempty"`
+
+	// SpamAction is the recommended action from the spam checker:
+	// "accept", "flag", "reject", "tempfail". Empty means no check was performed.
+	SpamAction string `json:"spam_action,omitempty"`
+
+	// SpamChecker identifies which checker produced the result (e.g., "rspamd").
+	SpamChecker string `json:"spam_checker,omitempty"`
 }

--- a/internal/smtp/execdeliver.go
+++ b/internal/smtp/execdeliver.go
@@ -65,6 +65,12 @@ func (a *ExecDeliveryAgent) Deliver(ctx context.Context, envelope msgstore.Envel
 	// See: infodancer/infodancer/docs/encryption-design.md
 	// ─────────────────────────────────────────────────────────────────────────
 
+	if envelope.SpamResult != nil {
+		req.SpamScore = envelope.SpamResult.Score
+		req.SpamAction = envelope.SpamResult.Action
+		req.SpamChecker = envelope.SpamResult.Checker
+	}
+
 	jsonBytes, err := json.Marshal(req)
 	if err != nil {
 		return fmt.Errorf("mail-deliver: marshalling envelope: %w", err)

--- a/internal/smtp/execdeliver_test.go
+++ b/internal/smtp/execdeliver_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"github.com/infodancer/msgstore"
-	smtpserver "github.com/infodancer/smtpd/internal/smtp"
 	"github.com/infodancer/smtpd/internal/maildeliver"
+	smtpserver "github.com/infodancer/smtpd/internal/smtp"
 )
 
 // buildFakeDeliver builds a minimal binary that reads all stdin and writes it
@@ -94,10 +94,71 @@ func TestExecDeliveryAgent_Format(t *testing.T) {
 		t.Errorf("recipients: got %v, want [rcpt@example.com]", req.Recipients)
 	}
 
+	// SpamResult fields should be absent when no spam result set.
+	if req.SpamAction != "" {
+		t.Errorf("SpamAction should be empty, got %q", req.SpamAction)
+	}
+	if req.SpamScore != 0 {
+		t.Errorf("SpamScore should be 0, got %f", req.SpamScore)
+	}
+
 	// Remainder after the JSON line must be the raw message bytes.
 	rest := string(data[idx+1:])
 	if !strings.Contains(rest, "Subject: test") {
 		t.Errorf("message body not found after JSON line; got: %q", rest)
+	}
+}
+
+// TestExecDeliveryAgent_SpamResult verifies that SpamResult on the envelope
+// is serialized to the wire protocol correctly.
+func TestExecDeliveryAgent_SpamResult(t *testing.T) {
+	t.Parallel()
+
+	outFile := filepath.Join(t.TempDir(), "captured.bin")
+	bin := buildFakeDeliver(t, outFile)
+
+	agent := smtpserver.NewExecDeliveryAgent(smtpserver.ExecDeliveryConfig{
+		Cmd:        bin,
+		ConfigPath: "/nonexistent/smtpd.toml",
+	})
+
+	envelope := msgstore.Envelope{
+		From:       "sender@example.com",
+		Recipients: []string{"rcpt@example.com"},
+		SpamResult: &msgstore.SpamResult{
+			Score:   8.3,
+			Action:  "flag",
+			Checker: "rspamd",
+		},
+	}
+	message := strings.NewReader("Subject: spam test\r\n\r\nbody\r\n")
+
+	if err := agent.Deliver(t.Context(), envelope, message); err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("reading captured output: %v", err)
+	}
+
+	idx := strings.IndexByte(string(data), '\n')
+	if idx < 0 {
+		t.Fatal("no newline in captured stdin")
+	}
+
+	var req maildeliver.DeliverRequest
+	if err := json.Unmarshal(data[:idx], &req); err != nil {
+		t.Fatalf("JSON decode: %v", err)
+	}
+	if req.SpamScore != 8.3 {
+		t.Errorf("SpamScore = %f, want 8.3", req.SpamScore)
+	}
+	if req.SpamAction != "flag" {
+		t.Errorf("SpamAction = %q, want %q", req.SpamAction, "flag")
+	}
+	if req.SpamChecker != "rspamd" {
+		t.Errorf("SpamChecker = %q, want %q", req.SpamChecker, "rspamd")
 	}
 }
 

--- a/internal/smtp/session.go
+++ b/internal/smtp/session.go
@@ -12,10 +12,10 @@ import (
 
 	"github.com/emersion/go-sasl"
 	"github.com/emersion/go-smtp"
+	"github.com/infodancer/auth/domain"
 	autherrors "github.com/infodancer/auth/errors"
 	"github.com/infodancer/msgstore"
 	"github.com/infodancer/smtpd/internal/config"
-	"github.com/infodancer/auth/domain"
 	"github.com/infodancer/smtpd/internal/queue"
 	"github.com/infodancer/smtpd/internal/spamcheck"
 )
@@ -47,8 +47,8 @@ func (b *fileTempBuf) cleanup() {
 type memTempBuf struct{ buf bytes.Buffer }
 
 func (b *memTempBuf) Write(p []byte) (int, error) { return b.buf.Write(p) }
-func (b *memTempBuf) reader() io.Reader            { return bytes.NewReader(b.buf.Bytes()) }
-func (b *memTempBuf) cleanup()                     {}
+func (b *memTempBuf) reader() io.Reader           { return bytes.NewReader(b.buf.Bytes()) }
+func (b *memTempBuf) cleanup()                    {}
 
 // newTempBuffer tries to create a temp file in dir (falling back to os.TempDir
 // when dir is ""). If file creation fails for any reason, it returns an
@@ -88,7 +88,7 @@ type Session struct {
 	clientIP         string
 	helo             string
 	from             string
-	mailFromSeen     bool // true once MAIL FROM is accepted (from may be "" for bounces)
+	mailFromSeen     bool     // true once MAIL FROM is accepted (from may be "" for bounces)
 	recipients       []string // local recipients → mail-deliver
 	remoteRecipients []string // remote recipients → queue (authenticated submission only)
 	authUser         string
@@ -412,6 +412,7 @@ func (s *Session) Data(r io.Reader) error {
 	counter := &countingReader{r: tee}
 
 	// Spam check (if enabled) - reads through counter, which fills tmpFile
+	var spamResult *spamcheck.CheckResult
 	if s.backend.spamChecker != nil && s.backend.spamConfig.IsEnabled() {
 		checkResult, checkErr := s.backend.spamChecker.Check(ctx, counter, spamcheck.CheckOptions{
 			From:       s.from,
@@ -511,8 +512,8 @@ func (s *Session) Data(r io.Reader) error {
 				}
 			}
 
-			// Note: Header injection is not supported with go-smtp.
-			// Spam check can reject but cannot modify the message.
+			// Preserve the result for the delivery envelope.
+			spamResult = checkResult
 		}
 	} else {
 		// No spam check - read the entire message into tmp
@@ -534,6 +535,13 @@ func (s *Session) Data(r io.Reader) error {
 			ReceivedTime:   time.Now(),
 			ClientIP:       net.ParseIP(s.clientIP),
 			ClientHostname: s.helo,
+		}
+		if spamResult != nil {
+			envelope.SpamResult = &msgstore.SpamResult{
+				Score:   spamResult.Score,
+				Action:  string(spamResult.Action),
+				Checker: spamResult.CheckerName,
+			}
 		}
 
 		if err := deliveryAgent.Deliver(ctx, envelope, tmp.reader()); err != nil {


### PR DESCRIPTION
## Summary

- Hoists `checkResult` from spam check block so it survives to envelope construction
- Populates `envelope.SpamResult` with score/action/checker after rspamd scoring
- Adds `SpamScore`/`SpamAction`/`SpamChecker` to the mail-deliver wire protocol
- `execdeliver.go` serializes, `mail-deliver/main.go` deserializes across the subprocess boundary

## Test plan

- [x] `TestExecDeliveryAgent_SpamResult` — spam fields survive wire round-trip
- [x] `TestExecDeliveryAgent_Format` — no spam fields when SpamResult is nil
- [x] Full smtpd test suite passes
- [x] Subprocess round-trip test with real mail-deliver binary passes

Depends on: infodancer/msgstore#23
Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)