### PR TITLE
Add Redis pub/sub notification after local delivery

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/infodancer/smtpd
 go 1.25.8
 
 require (
+	github.com/alicebob/miniredis/v2 v2.37.0
 	github.com/emersion/go-msgauth v0.7.0
 	github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6
 	github.com/emersion/go-smtp v0.24.0
@@ -10,6 +11,7 @@ require (
 	github.com/infodancer/msgstore v0.2.4
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/prometheus/client_golang v1.23.2
+	github.com/redis/go-redis/v9 v9.18.0
 )
 
 require (
@@ -17,6 +19,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/emersion/go-maildir v0.6.0 // indirect
 	github.com/goccy/go-json v0.10.3 // indirect
 	github.com/kr/text v0.2.0 // indirect
@@ -31,6 +34,8 @@ require (
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
+	go.uber.org/atomic v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,13 @@
 git.sr.ht/~emersion/go-sieve v0.0.0-20240926192256-cf8e1a9b5da9 h1:MaPyH1+nMX0azKxKQ+X6IiFWTlQokcKO5DKchAR9x5A=
 git.sr.ht/~emersion/go-sieve v0.0.0-20240926192256-cf8e1a9b5da9/go.mod h1:ewD6qhJ+zMwEeAElDEJOYYdkpxZSHRodJwq9Z0OG30w=
+github.com/alicebob/miniredis/v2 v2.37.0 h1:RheObYW32G1aiJIj81XVt78ZHJpHonHLHW7OLIshq68=
+github.com/alicebob/miniredis/v2 v2.37.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -10,6 +16,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 h1:NMZiJj8QnKe1LgsbDayM4UoHwbvwDRwnI3hwNaAHRnc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/emersion/go-maildir v0.6.0 h1:MPx2RSS1Xq8j1cNOzfq7YyF+5Leoeif1XqSeuytdET8=
 github.com/emersion/go-maildir v0.6.0/go.mod h1:Wpgtt9EOIJWe++WKa+JRvDwv+qIV7MeFdvZu/VbsXN4=
 github.com/emersion/go-msgauth v0.7.0 h1:vj2hMn6KhFtW41kshIBTXvp6KgYSqpA/ZN9Pv4g1INc=
@@ -28,6 +36,8 @@ github.com/infodancer/msgstore v0.2.4 h1:Rs/57J2iYJYbfu9+WprrjkryBohB2y/pjlEHECV
 github.com/infodancer/msgstore v0.2.4/go.mod h1:rW0pT8rguFR8OPbFoQyA7gk1X39at2q8YNmFFNnrx24=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
+github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
+github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -60,6 +70,8 @@ github.com/prometheus/common v0.66.1 h1:h5E0h5/Y8niHc5DlaLlWLArTQI7tMrsfQjHV+d9Z
 github.com/prometheus/common v0.66.1/go.mod h1:gcaUsgf3KfRSwHY4dIMXLPV0K/Wg1oZ8+SbZk/HH/dA=
 github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
+github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
+github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
@@ -69,6 +81,12 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
+github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
+github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
+go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
+go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.yaml.in/yaml/v2 v2.4.2 h1:DzmwEr2rDGHl7lsFgAHxmNz/1NlQ7xLIrlN2h5d1eGI=

--- a/internal/smtp/backend.go
+++ b/internal/smtp/backend.go
@@ -30,6 +30,7 @@ type Backend struct {
 	rejectionMode       config.RejectionMode
 	spamtrapLearner     *spamtrapLearner
 	spamtrapRateLimiter *ipRateLimiter
+	notifier            *Notifier
 	collector           metrics.Collector
 	maxRecipients       int
 	maxMessageSize      int64
@@ -50,6 +51,7 @@ type BackendConfig struct {
 	SpamConfig     config.SpamCheckConfig
 	RejectionMode  config.RejectionMode
 	SpamtrapConfig config.SpamtrapConfig
+	Notifier       *Notifier
 	Collector      metrics.Collector
 	MaxRecipients  int
 	MaxMessageSize int64
@@ -78,6 +80,7 @@ func NewBackend(cfg BackendConfig) *Backend {
 		spamChecker:    cfg.SpamChecker,
 		spamConfig:     cfg.SpamConfig,
 		rejectionMode:  cfg.RejectionMode,
+		notifier:       cfg.Notifier,
 		collector:      cfg.Collector,
 		maxRecipients:  cfg.MaxRecipients,
 		maxMessageSize: cfg.MaxMessageSize,

--- a/internal/smtp/notify.go
+++ b/internal/smtp/notify.go
@@ -1,0 +1,67 @@
+package smtp
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"log/slog"
+	"strings"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// Notifier publishes new-mail notifications to Redis pub/sub.
+// It is safe for concurrent use by multiple sessions.
+type Notifier struct {
+	client *redis.Client
+	logger *slog.Logger
+}
+
+// NewNotifier creates a Notifier from a Redis URL.
+// Returns nil if url is empty (notifications disabled).
+func NewNotifier(url, password string, logger *slog.Logger) (*Notifier, error) {
+	if url == "" {
+		return nil, nil
+	}
+	opts, err := redis.ParseURL(url)
+	if err != nil {
+		return nil, err
+	}
+	if password != "" {
+		opts.Password = password
+	}
+	return &Notifier{
+		client: redis.NewClient(opts),
+		logger: logger,
+	}, nil
+}
+
+// Close shuts down the Redis client.
+func (n *Notifier) Close() error {
+	if n == nil {
+		return nil
+	}
+	return n.client.Close()
+}
+
+// NotifyNewMail publishes a new-mail notification for the given recipient and folder.
+// Errors are logged but never returned — delivery must not fail due to notifications.
+func (n *Notifier) NotifyNewMail(ctx context.Context, recipient, folder string) {
+	if n == nil {
+		return
+	}
+	channel := MailChannel(recipient)
+	if err := n.client.Publish(ctx, channel, folder).Err(); err != nil {
+		n.logger.Warn("redis publish failed",
+			slog.String("channel", channel),
+			slog.String("error", err.Error()))
+	}
+}
+
+// MailChannel returns the Redis pub/sub channel name for a recipient address.
+// Format: mail:new:<hex(sha256(lowercase(addr))[:16])>
+// The hash prevents leaking email addresses to anyone with Redis access.
+func MailChannel(addr string) string {
+	h := sha256.Sum256([]byte(strings.ToLower(addr)))
+	return "mail:new:" + hex.EncodeToString(h[:16])
+}

--- a/internal/smtp/notify_test.go
+++ b/internal/smtp/notify_test.go
@@ -1,0 +1,112 @@
+package smtp
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+func TestMailChannel_Deterministic(t *testing.T) {
+	ch1 := MailChannel("alice@example.com")
+	ch2 := MailChannel("alice@example.com")
+	if ch1 != ch2 {
+		t.Errorf("MailChannel not deterministic: %q != %q", ch1, ch2)
+	}
+}
+
+func TestMailChannel_CaseInsensitive(t *testing.T) {
+	ch1 := MailChannel("Alice@Example.COM")
+	ch2 := MailChannel("alice@example.com")
+	if ch1 != ch2 {
+		t.Errorf("MailChannel not case-insensitive: %q != %q", ch1, ch2)
+	}
+}
+
+func TestMailChannel_Format(t *testing.T) {
+	ch := MailChannel("test@example.com")
+	if !strings.HasPrefix(ch, "mail:new:") {
+		t.Errorf("MailChannel prefix wrong: %q", ch)
+	}
+	// Should be "mail:new:" + 32 hex chars (16 bytes).
+	hexPart := strings.TrimPrefix(ch, "mail:new:")
+	if len(hexPart) != 32 {
+		t.Errorf("hex part length = %d, want 32", len(hexPart))
+	}
+	// Verify it matches the expected hash.
+	h := sha256.Sum256([]byte("test@example.com"))
+	want := hex.EncodeToString(h[:16])
+	if hexPart != want {
+		t.Errorf("hex = %q, want %q", hexPart, want)
+	}
+}
+
+func TestMailChannel_DifferentAddresses(t *testing.T) {
+	ch1 := MailChannel("alice@example.com")
+	ch2 := MailChannel("bob@example.com")
+	if ch1 == ch2 {
+		t.Error("different addresses should produce different channels")
+	}
+}
+
+func TestNotifier_PublishAndSubscribe(t *testing.T) {
+	mr := miniredis.RunT(t)
+
+	n, err := NewNotifier("redis://"+mr.Addr(), "", slog.Default())
+	if err != nil {
+		t.Fatalf("NewNotifier: %v", err)
+	}
+	defer func() { _ = n.Close() }()
+
+	// Subscribe to the channel.
+	ctx := context.Background()
+	sub := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer func() { _ = sub.Close() }()
+	pubsub := sub.Subscribe(ctx, MailChannel("alice@example.com"))
+	defer func() { _ = pubsub.Close() }()
+
+	// Wait for subscription to be active.
+	_, err = pubsub.Receive(ctx)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	// Publish.
+	n.NotifyNewMail(ctx, "alice@example.com", "INBOX")
+
+	// Receive.
+	msg, err := pubsub.ReceiveMessage(ctx)
+	if err != nil {
+		t.Fatalf("receive: %v", err)
+	}
+	if msg.Payload != "INBOX" {
+		t.Errorf("payload = %q, want INBOX", msg.Payload)
+	}
+	if msg.Channel != MailChannel("alice@example.com") {
+		t.Errorf("channel = %q, want %q", msg.Channel, MailChannel("alice@example.com"))
+	}
+}
+
+func TestNotifier_Nil_NoOp(t *testing.T) {
+	// A nil Notifier should not panic.
+	var n *Notifier
+	n.NotifyNewMail(context.Background(), "alice@example.com", "INBOX")
+	if err := n.Close(); err != nil {
+		t.Errorf("nil Close: %v", err)
+	}
+}
+
+func TestNewNotifier_EmptyURL(t *testing.T) {
+	n, err := NewNotifier("", "", slog.Default())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != nil {
+		t.Error("expected nil Notifier for empty URL")
+	}
+}

--- a/internal/smtp/session.go
+++ b/internal/smtp/session.go
@@ -616,6 +616,15 @@ func (s *Session) Data(r io.Reader) error {
 			}
 		}
 
+		// Notify Redis pub/sub so IMAP IDLE clients see new mail.
+		folder := "INBOX"
+		if checkResult != nil && checkResult.Action == spamcheck.ActionFlag {
+			folder = "Junk"
+		}
+		for _, rcpt := range s.recipients {
+			s.backend.notifier.NotifyNewMail(ctx, rcpt, folder)
+		}
+
 		if s.backend.collector != nil {
 			recipientDomain := sessionExtractRecipientDomain(s.recipients)
 			s.backend.collector.MessageReceived(recipientDomain, counter.n)

--- a/internal/smtp/stack.go
+++ b/internal/smtp/stack.go
@@ -150,6 +150,19 @@ func NewStack(cfg StackConfig) (*Stack, error) {
 		}
 	}
 
+	// Create Redis notifier for IMAP IDLE new-mail notifications.
+	var notifier *Notifier
+	if cfg.Config.Redis.URL != "" {
+		var err error
+		notifier, err = NewNotifier(cfg.Config.Redis.URL, cfg.Config.Redis.Password, logger)
+		if err != nil {
+			s.Close() //nolint:errcheck
+			return nil, err
+		}
+		s.closers = append(s.closers, notifier)
+		logger.Info("redis notifier enabled", "url", cfg.Config.Redis.URL)
+	}
+
 	backend := NewBackend(BackendConfig{
 		Hostname:       cfg.Config.Hostname,
 		Delivery:       delivery,
@@ -161,6 +174,7 @@ func NewStack(cfg StackConfig) (*Stack, error) {
 		SpamConfig:     cfg.SpamConfig,
 		RejectionMode:  cfg.Config.GetRejectionMode(),
 		SpamtrapConfig: cfg.Config.Spamtrap,
+		Notifier:       notifier,
 		Collector:      collector,
 		MaxRecipients:  cfg.Config.Limits.MaxRecipients,
 		MaxMessageSize: int64(cfg.Config.Limits.MaxMessageSize),


### PR DESCRIPTION
## Summary

- Add `Notifier` type that publishes to Redis pub/sub after successful local delivery
- Channel: `mail:new:<sha256_prefix(recipient)>` — hashed to avoid leaking addresses in Redis
- Payload: folder name (`"INBOX"` or `"Junk"` based on spam check `ActionFlag`)
- Fire-and-forget: errors logged, never fail delivery
- Redis client created once at Stack startup, nil-safe when Redis not configured

Step 2 of the Redis IMAP IDLE notification plan.

Closes #75

## Test plan

- [x] `MailChannel()` hash tests: deterministic, case-insensitive, correct format, different addresses differ
- [x] `Notifier` pub/sub test with miniredis: publish + subscribe round-trip
- [x] Nil notifier no-op (no panic)
- [x] Empty URL returns nil notifier
- [x] All existing tests pass with `-race`
- [x] `go vet`, `golangci-lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)