### PR TITLE
Enforce sender verification for authenticated submission

### DIFF
--- a/internal/smtp/session.go
+++ b/internal/smtp/session.go
@@ -142,7 +142,7 @@ func (s *Session) Auth(mech string) (sasl.Server, error) {
 			}
 
 			// AuthRouter handles domain splitting for user@domain usernames
-			session, err := s.backend.authRouter.Authenticate(ctx, username, password)
+			_, err := s.backend.authRouter.Authenticate(ctx, username, password)
 			if err != nil {
 				if s.backend.collector != nil {
 					domain := sessionExtractAuthDomain(username)
@@ -176,11 +176,10 @@ func (s *Session) Auth(mech string) (sasl.Server, error) {
 				}
 			}
 
-			if session != nil && session.User != nil {
-				s.authUser = session.User.Username
-			} else {
-				s.authUser = username
-			}
+			// Always use the full login username (user@domain) for sender
+			// verification. The auth session's User.Username may be the
+			// bare local part without domain.
+			s.authUser = username
 
 			if s.backend.collector != nil {
 				domain := sessionExtractAuthDomain(username)
@@ -242,6 +241,23 @@ func (s *Session) Auth(mech string) (sasl.Server, error) {
 // Mail handles the MAIL FROM command.
 // Implements smtp.Session interface.
 func (s *Session) Mail(from string, opts *smtp.MailOptions) error {
+	// Sender verification: authenticated users may only send from their own domain.
+	// Bounce messages (empty sender) are exempt — they're legitimate in submission.
+	if s.authUser != "" && from != "" {
+		fromDomain := extractDomain(from)
+		authDomain := sessionExtractAuthDomain(s.authUser)
+		if !strings.EqualFold(fromDomain, authDomain) {
+			s.logger.Warn("sender verification failed",
+				slog.String("auth_user", s.authUser),
+				slog.String("from", from))
+			return &smtp.SMTPError{
+				Code:         553,
+				EnhancedCode: smtp.EnhancedCode{5, 7, 1},
+				Message:      "Sender address not authorized for this account",
+			}
+		}
+	}
+
 	s.from = from
 	s.mailFromSeen = true
 

--- a/internal/smtp/session_test.go
+++ b/internal/smtp/session_test.go
@@ -317,6 +317,88 @@ func TestSession_Rcpt_DomainValidation(t *testing.T) {
 	})
 }
 
+func TestSession_Mail_SenderVerification(t *testing.T) {
+	logger := slog.Default()
+
+	t.Run("unauthenticated allows any sender", func(t *testing.T) {
+		session := &Session{
+			backend: &Backend{},
+			logger:  logger,
+		}
+		err := session.Mail("anyone@anywhere.com", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("authenticated allows matching domain", func(t *testing.T) {
+		session := &Session{
+			backend:  &Backend{},
+			authUser: "matthew@example.com",
+			logger:   logger,
+		}
+		err := session.Mail("matthew@example.com", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("authenticated allows different local part same domain", func(t *testing.T) {
+		session := &Session{
+			backend:  &Backend{},
+			authUser: "matthew@example.com",
+			logger:   logger,
+		}
+		err := session.Mail("noreply@example.com", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("authenticated rejects different domain", func(t *testing.T) {
+		session := &Session{
+			backend:  &Backend{},
+			authUser: "matthew@example.com",
+			logger:   logger,
+		}
+		err := session.Mail("matthew@otherdomain.com", nil)
+		if err == nil {
+			t.Fatal("expected error for mismatched domain")
+		}
+		smtpErr, ok := err.(*gosmtp.SMTPError)
+		if !ok {
+			t.Fatalf("expected SMTPError, got %T", err)
+		}
+		if smtpErr.Code != 553 {
+			t.Errorf("expected code 553, got %d", smtpErr.Code)
+		}
+	})
+
+	t.Run("authenticated allows bounce (empty sender)", func(t *testing.T) {
+		session := &Session{
+			backend:  &Backend{},
+			authUser: "matthew@example.com",
+			logger:   logger,
+		}
+		err := session.Mail("", nil)
+		if err != nil {
+			t.Fatalf("unexpected error for bounce: %v", err)
+		}
+	})
+
+	t.Run("case insensitive domain match", func(t *testing.T) {
+		session := &Session{
+			backend:  &Backend{},
+			authUser: "matthew@Example.COM",
+			logger:   logger,
+		}
+		err := session.Mail("matthew@example.com", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
 func TestExtractDomain(t *testing.T) {
 	tests := []struct {
 		email    string


### PR DESCRIPTION
## Summary
- Reject MAIL FROM with `553 5.7.1` when sender domain doesn't match auth user's domain
- Prevents any authenticated account from spoofing arbitrary sender addresses
- Bounce messages (empty sender) remain allowed
- Fix `authUser` to always use full login username (`user@domain`) for reliable domain extraction

Closes #89

## Test plan
- [x] New unit tests: matching domain, mismatched domain, different local part, bounce, case-insensitive, unauthenticated
- [x] Existing `TestRoundTrip_SMTP_AuthenticatedDelivery` passes (previously used bare username)
- [x] Full test suite passes
- [ ] Deploy and verify Thunderbird submission still works
- [ ] Verify spoofed sender is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)