### PR TITLE
Switch sender rate limiter to Redis for cross-subprocess state

### DIFF
--- a/internal/smtp/backend.go
+++ b/internal/smtp/backend.go
@@ -3,6 +3,7 @@ package smtp
 import (
 	"log/slog"
 	"net"
+	"time"
 
 	"github.com/emersion/go-smtp"
 	"github.com/infodancer/auth"
@@ -13,6 +14,7 @@ import (
 	"github.com/infodancer/smtpd/internal/logging"
 	"github.com/infodancer/smtpd/internal/metrics"
 	"github.com/infodancer/smtpd/internal/spamcheck"
+	"github.com/redis/go-redis/v9"
 )
 
 // Backend implements the go-smtp Backend interface.
@@ -30,7 +32,7 @@ type Backend struct {
 	rejectionMode       config.RejectionMode
 	spamtrapLearner     *spamtrapLearner
 	spamtrapRateLimiter *ipRateLimiter
-	senderRateLimiter   *ipRateLimiter
+	senderRateLimiter   senderLimiter
 	notifier            *Notifier
 	collector           metrics.Collector
 	maxRecipients       int
@@ -53,6 +55,7 @@ type BackendConfig struct {
 	RejectionMode   config.RejectionMode
 	SpamtrapConfig  config.SpamtrapConfig
 	MaxSendsPerHour int
+	RedisClient     *redis.Client // shared Redis for cross-subprocess rate limiting
 	Notifier        *Notifier
 	Collector       metrics.Collector
 	MaxRecipients   int
@@ -90,8 +93,9 @@ func NewBackend(cfg BackendConfig) *Backend {
 		logger:         logger,
 	}
 
-	if cfg.MaxSendsPerHour > 0 {
-		b.senderRateLimiter = newIPRateLimiter(cfg.MaxSendsPerHour)
+	if cfg.MaxSendsPerHour > 0 && cfg.RedisClient != nil {
+		b.senderRateLimiter = newRedisRateLimiter(
+			cfg.RedisClient, cfg.MaxSendsPerHour, time.Hour, "smtpd:sendrate:")
 		logger.Info("sender rate limiting enabled",
 			"max_sends_per_hour", cfg.MaxSendsPerHour)
 	}

--- a/internal/smtp/notify.go
+++ b/internal/smtp/notify.go
@@ -36,6 +36,16 @@ func NewNotifier(url, password string, logger *slog.Logger) (*Notifier, error) {
 	}, nil
 }
 
+// NewNotifierFromClient creates a Notifier from an existing Redis client.
+// The caller retains ownership of the client — Close on the Notifier is a no-op
+// for the underlying connection.
+func NewNotifierFromClient(client *redis.Client, logger *slog.Logger) *Notifier {
+	return &Notifier{
+		client: client,
+		logger: logger,
+	}
+}
+
 // Close shuts down the Redis client.
 func (n *Notifier) Close() error {
 	if n == nil {

--- a/internal/smtp/ratelimit.go
+++ b/internal/smtp/ratelimit.go
@@ -2,7 +2,6 @@ package smtp
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -89,21 +88,4 @@ func (r *memRateLimiter) allow(_ context.Context, key string) bool {
 	}
 	bucket.count++
 	return true
-}
-
-// remaining returns the number of sends remaining for the key, or an error.
-func (r *redisRateLimiter) remaining(ctx context.Context, key string) (int, error) {
-	redisKey := r.prefix + key
-	count, err := r.client.Get(ctx, redisKey).Int()
-	if err == redis.Nil {
-		return r.maxRate, nil
-	}
-	if err != nil {
-		return 0, fmt.Errorf("redis get: %w", err)
-	}
-	rem := r.maxRate - count
-	if rem < 0 {
-		rem = 0
-	}
-	return rem, nil
 }

--- a/internal/smtp/ratelimit.go
+++ b/internal/smtp/ratelimit.go
@@ -1,0 +1,109 @@
+package smtp
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// senderLimiter is the interface for per-sender rate limiting.
+type senderLimiter interface {
+	allow(ctx context.Context, key string) bool
+}
+
+// redisRateLimiter enforces per-key rate limits using Redis INCR + EXPIRE.
+// Safe for use across multiple subprocesses sharing the same Redis instance.
+type redisRateLimiter struct {
+	client  *redis.Client
+	maxRate int
+	window  time.Duration
+	prefix  string
+}
+
+// newRedisRateLimiter creates a rate limiter backed by Redis.
+// prefix distinguishes different rate limit namespaces (e.g. "smtpd:sendrate:").
+func newRedisRateLimiter(client *redis.Client, maxRate int, window time.Duration, prefix string) *redisRateLimiter {
+	return &redisRateLimiter{
+		client:  client,
+		maxRate: maxRate,
+		window:  window,
+		prefix:  prefix,
+	}
+}
+
+// allow returns true if the key is under the rate limit and increments the counter.
+// On Redis errors, it fails open (allows the request) to avoid blocking mail delivery.
+func (r *redisRateLimiter) allow(_ context.Context, key string) bool {
+	ctx := context.Background()
+	redisKey := r.prefix + key
+
+	// INCR + conditional EXPIRE is atomic enough: even if two subprocesses
+	// race on a new key, both will INCR and the first EXPIRE wins.
+	count, err := r.client.Incr(ctx, redisKey).Result()
+	if err != nil {
+		return true // fail open
+	}
+
+	// Set expiry only when we just created the key (count == 1).
+	if count == 1 {
+		r.client.Expire(ctx, redisKey, r.window)
+	}
+
+	return count <= int64(r.maxRate)
+}
+
+// memRateLimiter is an in-memory rate limiter for testing.
+type memRateLimiter struct {
+	mu      sync.Mutex
+	counts  map[string]*memBucket
+	maxRate int
+}
+
+type memBucket struct {
+	count   int
+	resetAt time.Time
+}
+
+func newMemRateLimiter(maxPerHour int) *memRateLimiter {
+	return &memRateLimiter{
+		counts:  make(map[string]*memBucket),
+		maxRate: maxPerHour,
+	}
+}
+
+func (r *memRateLimiter) allow(_ context.Context, key string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	now := time.Now()
+	bucket, ok := r.counts[key]
+	if !ok || now.After(bucket.resetAt) {
+		r.counts[key] = &memBucket{count: 1, resetAt: now.Add(time.Hour)}
+		return true
+	}
+	if bucket.count >= r.maxRate {
+		return false
+	}
+	bucket.count++
+	return true
+}
+
+// remaining returns the number of sends remaining for the key, or an error.
+func (r *redisRateLimiter) remaining(ctx context.Context, key string) (int, error) {
+	redisKey := r.prefix + key
+	count, err := r.client.Get(ctx, redisKey).Int()
+	if err == redis.Nil {
+		return r.maxRate, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("redis get: %w", err)
+	}
+	rem := r.maxRate - count
+	if rem < 0 {
+		rem = 0
+	}
+	return rem, nil
+}

--- a/internal/smtp/session.go
+++ b/internal/smtp/session.go
@@ -241,9 +241,9 @@ func (s *Session) Auth(mech string) (sasl.Server, error) {
 // Mail handles the MAIL FROM command.
 // Implements smtp.Session interface.
 func (s *Session) Mail(from string, opts *smtp.MailOptions) error {
-	// Per-sender rate limiting for authenticated submission.
+	// Per-sender rate limiting for authenticated submission (Redis-backed).
 	if s.authUser != "" && s.backend.senderRateLimiter != nil {
-		if !s.backend.senderRateLimiter.allow(s.authUser) {
+		if !s.backend.senderRateLimiter.allow(context.Background(), s.authUser) {
 			s.logger.Warn("sender rate limit exceeded",
 				slog.String("auth_user", s.authUser))
 			return &smtp.SMTPError{

--- a/internal/smtp/session_test.go
+++ b/internal/smtp/session_test.go
@@ -422,7 +422,7 @@ func TestSession_Mail_SenderRateLimit(t *testing.T) {
 	logger := slog.Default()
 
 	t.Run("rate limit enforced for authenticated sender", func(t *testing.T) {
-		limiter := newIPRateLimiter(3)
+		limiter := newMemRateLimiter(3)
 		backend := &Backend{senderRateLimiter: limiter}
 		session := &Session{
 			backend:  backend,
@@ -454,7 +454,7 @@ func TestSession_Mail_SenderRateLimit(t *testing.T) {
 	})
 
 	t.Run("no rate limit for unauthenticated", func(t *testing.T) {
-		limiter := newIPRateLimiter(1)
+		limiter := newMemRateLimiter(1)
 		backend := &Backend{senderRateLimiter: limiter}
 		session := &Session{
 			backend: backend,
@@ -489,7 +489,7 @@ func TestSession_Mail_SenderRateLimit(t *testing.T) {
 	})
 
 	t.Run("separate limits per sender", func(t *testing.T) {
-		limiter := newIPRateLimiter(2)
+		limiter := newMemRateLimiter(2)
 		backend := &Backend{senderRateLimiter: limiter}
 
 		alice := &Session{backend: backend, authUser: "alice@example.com", logger: logger}

--- a/internal/smtp/stack.go
+++ b/internal/smtp/stack.go
@@ -14,6 +14,7 @@ import (
 	"github.com/infodancer/smtpd/internal/config"
 	"github.com/infodancer/smtpd/internal/metrics"
 	"github.com/infodancer/smtpd/internal/spamcheck"
+	goredis "github.com/redis/go-redis/v9"
 )
 
 // Stack owns all components of a running smtpd instance and manages their lifecycle.
@@ -153,17 +154,22 @@ func NewStack(cfg StackConfig) (*Stack, error) {
 		tempDir = filepath.Join(cfg.Config.Delivery.BasePath, "tmp")
 	}
 
-	// Create Redis notifier for IMAP IDLE new-mail notifications.
+	// Create shared Redis client for notifications and rate limiting.
+	var redisClient *goredis.Client
 	var notifier *Notifier
 	if cfg.Config.Redis.URL != "" {
-		var err error
-		notifier, err = NewNotifier(cfg.Config.Redis.URL, cfg.Config.Redis.Password, logger)
+		opts, err := goredis.ParseURL(cfg.Config.Redis.URL)
 		if err != nil {
 			s.Close() //nolint:errcheck
 			return nil, err
 		}
+		if cfg.Config.Redis.Password != "" {
+			opts.Password = cfg.Config.Redis.Password
+		}
+		redisClient = goredis.NewClient(opts)
+		notifier = NewNotifierFromClient(redisClient, logger)
 		s.closers = append(s.closers, notifier)
-		logger.Info("redis notifier enabled", "url", cfg.Config.Redis.URL)
+		logger.Info("redis enabled", "url", cfg.Config.Redis.URL)
 	}
 
 	backend := NewBackend(BackendConfig{
@@ -178,6 +184,7 @@ func NewStack(cfg StackConfig) (*Stack, error) {
 		RejectionMode:   cfg.Config.GetRejectionMode(),
 		SpamtrapConfig:  cfg.Config.Spamtrap,
 		MaxSendsPerHour: cfg.Config.Limits.MaxSendsPerHour,
+		RedisClient:     redisClient,
 		Notifier:        notifier,
 		Collector:       collector,
 		MaxRecipients:   cfg.Config.Limits.MaxRecipients,


### PR DESCRIPTION
## Summary
- Replace in-memory rate limiter with Redis-backed INCR + EXPIRE
- Shared Redis client (same as IMAP IDLE notifier) for cross-subprocess counting
- `senderLimiter` interface with Redis and in-memory (test) implementations
- Fails open on Redis errors to avoid blocking delivery

Closes #93

## Test plan
- [x] Unit tests pass (using in-memory limiter)
- [x] Full test suite passes
- [ ] Deploy and verify rate limit log appears when exceeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)